### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix 0.0.0.0 bind

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -184,3 +184,7 @@
 **Vulnerability:** `GitRepoSubAgent` executed `subprocess.run(["git", "clone", repo_url, repo_path])`. If an attacker supplies a URL starting with `-` (like `--upload-pack=...`), `git` interprets it as an option instead of a URL, leading to arbitrary code execution (Command Option Injection).
 **Learning:** External commands that accept positional arguments (like `git`, `tar`, `curl`) can be tricked into interpreting those arguments as flags if they start with a hyphen. Validating URL scheme is good but sometimes bypasses exist or are added later.
 **Prevention:** Always use the end-of-options separator `--` before untrusted arguments in `subprocess` calls (e.g., `["git", "clone", "--", repo_url, repo_path]`) to force the command to treat them as positional arguments.
+## 2026-04-12 - Prevent binding to all interfaces (0.0.0.0)
+**Vulnerability:** Fast API application was binding to all interfaces (0.0.0.0), exposing it to external networks unnecessarily.
+**Learning:** Found in `services/sentinel_api.py`. Uvicorn bound to 0.0.0.0 by default. It must be explicitly bound to 127.0.0.1 for local deployments.
+**Prevention:** Configure local APIs to bind to localhost (127.0.0.1) explicitly unless external access is required. Use bandit `uv run bandit` to scan for these risks.

--- a/adam_project.egg-info/SOURCES.txt
+++ b/adam_project.egg-info/SOURCES.txt
@@ -626,6 +626,7 @@ core/schemas/financial_truth.py
 core/schemas/hnasp.py
 core/schemas/hnasp_integration.py
 core/schemas/hnasp_v3.py
+core/schemas/illiquid_market_schema.py
 core/schemas/json_rpc.py
 core/schemas/knowledge_graph.py
 core/schemas/market_data_schema.py

--- a/services/sentinel_api.py
+++ b/services/sentinel_api.py
@@ -44,4 +44,5 @@ async def evaluate_risk(request: EvaluationRequest):
 
 if __name__ == "__main__":
     import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8001)
+    # SECURITY: Bind to localhost (127.0.0.1) instead of 0.0.0.0 to prevent external access during local dev
+    uvicorn.run(app, host="127.0.0.1", port=8001)


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: FastAPI app bound to all interfaces (0.0.0.0), exposing it unnecessarily to external networks.
🎯 Impact: Could allow an attacker to bypass local firewalls and interact directly with the FastAPI server on exposed ports.
🔧 Fix: Replaced 0.0.0.0 with 127.0.0.1 in `services/sentinel_api.py`.
✅ Verification: Ran bandit check (`uv run bandit`) to ensure B104 was cleared. Evaluated tests.

---
*PR created automatically by Jules for task [11358147318101280253](https://jules.google.com/task/11358147318101280253) started by @adamvangrover*