### PR TITLE
Fix ConsensusEngine logic for ADAM-V-NEXT evaluation parity

### DIFF
--- a/core/engine/consensus_engine.py
+++ b/core/engine/consensus_engine.py
@@ -93,7 +93,11 @@ class ConsensusEngine:
         else:
             decision = 'HOLD'
 
-        return {'decision': decision, 'score': score}
+        rationale = " | ".join(
+            [f"{s.get('agent', 'Unknown')} voted {s.get('vote', '')}: {s.get('reason', '')}" for s in signals]
+        )
+
+        return {'decision': decision, 'score': score, 'rationale': rationale}
 
     def arbitrate(self, agent_outputs: List[Dict[str, Any]], risk_profile: str = "moderate") -> Dict[str, Any]:
         """


### PR DESCRIPTION
Fixes the test regression in `test_adam_v_next.py` where the ConsensusEngine evaluation logic lacked the expected `rationale` key in the returned dictionary. This completes the implementation requirements outlined in the issue.

---
*PR created automatically by Jules for task [11751214637580023230](https://jules.google.com/task/11751214637580023230) started by @adamvangrover*