### PR TITLE
Expand weekly execution plans to cover all repo domains

### DIFF
--- a/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_friday.md
+++ b/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_friday.md
@@ -1,0 +1,23 @@
+# Friday Execution Plan: The Innovator (AI Capability Expansion)
+
+**Objective**: Apply "The Innovator" sequentially across all major repository domains over a 12-week timeline. Integrate cutting-edge AI capabilities, autonomous behaviors, and advanced LLM pipelines natively into the system.
+
+## Phase 1: V30 Architecture and Agent Capabilities (Weeks 1-3)
+* **Week 1 (Neural Mesh Enhancements)**: Target `core/v30_architecture/`. Propose and implement a new inter-agent communication protocol via `NeuralPacket` to allow agents to debate and reach consensus autonomously before emitting a final decision.
+* **Week 2 (Dynamic Search Upgrades)**: Enhance the `DynamicSearchAgent`. Integrate an advanced RAG (Retrieval-Augmented Generation) pipeline that utilizes vector embeddings to ground the 'DEEP DIVE' 12-18 month predictive actionable ideas.
+* **Week 3 (Self-Healing Evaluation)**: Target `backend/eval_harness.py`. Implement an LLM-driven anomaly detection judge that autonomously identifies and reports deviations in the deterministic logic gates without manual configuration.
+
+## Phase 2: Operations and Script Automation (Weeks 4-6)
+* **Week 4 (Protocol ARCHITECT_INFINITE)**: Upgrade `scripts/daily_ritual.py`. Enhance the LLM integration to allow the script to autonomously select the best fallback model (via `litellm`) based on current latency and cost metrics.
+* **Week 5 (Smart Data Generation)**: Enhance dashboard generation scripts (e.g., `generate_predictive_reports.py`). Implement smart parsing to automatically categorize distress reports and search logs into structured, hierarchical JSON for the UI.
+* **Week 6 (Automated Code Review)**: Build a prototype script in `experimental/` that uses an LLM to pre-review PRs against the project's specific memory and style guidelines (e.g., checking for `sys.path.append` usage).
+
+## Phase 3: Frontend AI Integration (Weeks 7-9)
+* **Week 7 (Interactive Terminal UI)**: Target `MarketMayhem.tsx`. Integrate a natural language query bar that allows users to filter the 3-stage illiquid market maker dashboard using conversational prompts rather than static UI controls.
+* **Week 8 (Predictive Visualizations)**: Enhance `showcase/predictive_deep_dives.html`. Use an LLM to generate dynamic text summaries explaining the trends depicted in the machine learning dataset JSON blobs.
+* **Week 9 (Context-Aware Navigation)**: Implement a smart 'Daily Terminal' navigation system that highlights the most relevant adjacent dates based on the user's current reading context, rather than simple sequential navigation.
+
+## Phase 4: Mock Ecosystem and Synthetic Data (Weeks 10-12)
+* **Week 10 (Dynamic Mock Generation)**: Upgrade `config/mocks/mock_llm_generator.py`. Instead of static text fallbacks, use a lightweight, local model (if available) or complex heuristics to generate highly varied, contextually appropriate synthetic responses for testing.
+* **Week 11 (Adversarial Testing Simulation)**: Create a new pipeline in `core/` that autonomously generates edge-case financial data and feeds it into the `rust_pricing` engine to test its robustness under chaotic market conditions.
+* **Week 12 (System Validation)**: Review all new AI integrations against the project's 'MockLLM' snapshot philosophy. Ensure every new feature degrades gracefully and functions entirely locally or via explicit mock proxies when `MOCK_MODE=true`.

--- a/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_monday.md
+++ b/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_monday.md
@@ -1,0 +1,23 @@
+# Monday Execution Plan: The Pruning (Comprehensive System Purge)
+
+**Objective**: Apply "The Pruning" sequentially across all major repository domains over a 12-week timeline. Strip bloat, unused imports, dead code, and legacy artifacts to improve clarity across the entire swarm architecture.
+
+## Phase 1: Core Engine and Backend Purge (Weeks 1-3)
+* **Week 1 (Backend API & Controller)**: Run static analysis tools (`uv run ruff`) on `backend/api.py` and `backend/controller.py`. Remove deprecated API endpoints, unused LLM logic gate variants, and obsolete telemetry trackers.
+* **Week 2 (Core v30 Architecture)**: Target `core/v30_architecture/python_intelligence/`. Prune unreferenced agent definitions and orphaned helper functions. Remove legacy `sys.path.append` hacks.
+* **Week 3 (Legacy Agent Purge)**: Target `core/agents/`. Identify and purge deprecated pre-v29 agent logic that has been fully superseded by the v30 architecture. Ensure `EngineFactory` fallback logic remains intact.
+
+## Phase 2: Operations, Scripts, and Automation (Weeks 4-6)
+* **Week 4 (Operational Scripts)**: Scan the `scripts/` directory. Delete iterative LLM generation artifacts (e.g., temporary `patch_*.py` files). Consolidate redundant daily generation scripts (e.g., merging overlapping `generate_daily_index.py` tasks).
+* **Week 5 (Repo Maintenance & Docker)**: Prune unused or redundant containers from `docker/docker-compose.yml`. Clean up legacy `.sh` startup scripts that conflict with the modern `uv` pipeline.
+* **Week 6 (Archive Cleanup)**: Systematically review `archive/` and temporary `.log` files in the root. Permanently delete outdated UI backups (e.g., `index2.html`) and enforce `.gitignore` rules against future clutter.
+
+## Phase 3: Data, Mocks, and Prompt Libraries (Weeks 7-9)
+* **Week 7 (Mock Ecosystem)**: Audit `config/mocks/` and mock connectors (e.g., `MockLLM` in `core/llm_plugin.py`). Ensure all empty text stubs are removed and replaced with functional, typed Pydantic fallback logic to maintain graceful degradation.
+* **Week 8 (Data Artifacts)**: Target `showcase/` and `verification_images/`. Identify orphaned JSON data blobs or screenshots that are no longer referenced by the generated HTML dashboards.
+* **Week 9 (Prompt Library Consolidation)**: Scan `prompt_library/AOPL-v2.0/`. Remove redundant or outdated prompt variations. Consolidate overlapping prompts for the `DynamicSearchAgent`.
+
+## Phase 4: Frontend, Tests, and Validation (Weeks 10-12)
+* **Week 10 (Webapp UI Pruning)**: Target `services/webapp/client/`. Remove unused React components, obsolete CSS classes (ensure adherence to the 'Cyberpunk' theme), and dead TypeScript interfaces.
+* **Week 11 (Test Suite Trimming)**: Scan the `tests/` directory. Remove obsolete tests for purged pre-v29 agents. Address or safely ignore known unfixable test collection errors as specified in memory.
+* **Week 12 (Global Verification)**: Run the full `uv run bandit` and `uv run pytest` suites. Ensure the aggressive pruning across all domains has not introduced regressions or violated the 'Static Mock Mode' fallback contract.

--- a/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_saturday.md
+++ b/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_saturday.md
@@ -1,0 +1,23 @@
+# Saturday Execution Plan: The Documenter (Global Knowledge Base)
+
+**Objective**: Apply "The Documenter" sequentially across all major repository domains over a 12-week timeline. Ensure the entire codebase is perfectly documented, facilitating instant understanding for future AI context windows and human developers.
+
+## Phase 1: Core Systems and Architecture (Weeks 1-3)
+* **Week 1 (v30 Architecture Docs)**: Document `core/v30_architecture/python_intelligence/`. Ensure all `BaseAgent` implementations, `NeuralMesh` interactions, and `emit_packet` workflows have comprehensive docstrings and usage examples.
+* **Week 2 (Engine Factory Documentation)**: Document `core/engine/factory.py` and the Rust Execution layer (`core/rust_pricing/`). Detail the graceful fallback mechanism, PyO3 bindings, and data handoff structures.
+* **Week 3 (Architectural Review Sync)**: Update `Architectural_Review_Refined.md`. Ensure the current state of Phase 1 and 2 refactoring is accurately reflected under the appropriate sequential markdown headings.
+
+## Phase 2: Operations and Scripts (Weeks 4-6)
+* **Week 4 (Daily Ritual Documentation)**: Document `scripts/daily_ritual.py`. Clearly explain Protocol ARCHITECT_INFINITE, the regex-based parsing logic, and the `MOCK_PAYLOAD` fallback mechanisms.
+* **Week 5 (Generation Script Registry)**: Document the various `generate_*.py` scripts. Create a master index in the `README.md` or a dedicated `scripts/README.md` explaining what HTML dashboards each script generates (e.g., `showcase/comprehensive_index.html`).
+* **Week 6 (Docker and Environment)**: Document `docker/docker-compose.yml`. Explain the purpose of each deployment pathway (`core-engine-legacy`, `swarm-engine`, `modern-engine`) and how to invoke them locally.
+
+## Phase 3: Frontend and User Interfaces (Weeks 7-9)
+* **Week 7 (React Component Library)**: Document `services/webapp/client/`. Generate JSDoc/TSDoc comments for complex components like `MarketMayhem.tsx`, detailing the 3-stage interactive workflow (Directory, Tearsheet, Drill-Down).
+* **Week 8 (Dashboard Schemas)**: Document the JavaScript array structures (`const modules = [...]`) required by scripts like `generate_daily_index.py` to correctly render masonry card grids and gated content modals.
+* **Week 9 (Design Language System)**: Formalize the 'Bloomberg Terminal meets Cyberpunk' aesthetic guidelines in a frontend documentation file, detailing color palettes, typography, and UI paradigms.
+
+## Phase 4: Prompts, Mocks, and Continuous Learning (Weeks 10-12)
+* **Week 10 (AOPL Structure)**: Document the Adam Operational Prompt Library (`prompt_library/AOPL-v2.0/`). Explain the organization of domain-specific prompts and the Dynamic Search Hierarchy graceful fallback strategies.
+* **Week 11 (Mock Ecosystem Guide)**: Document the 'Static Mock Mode' fallback contract. Explain how to engage it (`MOCK_MODE=true`), where proxies are located (`config/mocks/`), and the rules for building new functional mock stubs.
+* **Week 12 (Sentinel Knowledge Capture)**: Review `.jules/sentinel.md` and `.jules/bolt.md`. Consolidate critical learnings and ensure the required markdown format (`## YYYY-MM-DD - [Title]...`) is strictly adhered to for future knowledge transfer.

--- a/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_sunday.md
+++ b/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_sunday.md
@@ -1,0 +1,23 @@
+# Sunday Execution Plan: The Validator (Comprehensive Test Coverage)
+
+**Objective**: Apply "The Validator" sequentially across all major repository domains over a 12-week timeline. Generate comprehensive unit, integration, and UI tests to lock in progress and ensure system stability.
+
+## Phase 1: Core Engine and Backend Validation (Weeks 1-3)
+* **Week 1 (v30 Agent Tests)**: Target `core/v30_architecture/`. Write isolated unit tests for all derived `BaseAgent` classes, ensuring the `execute(**kwargs)` method handles parameters correctly and emits appropriate `NeuralPacket` objects.
+* **Week 2 (Engine Factory Tests)**: Target `core/engine/factory.py`. Write integration tests that simulate primary Rust layer (`RealTradingEngine`) failures and assert that the `LiveMockEngine` fallback engages smoothly without data loss.
+* **Week 3 (API and Controller Tests)**: Target `backend/`. Use FastAPI's `TestClient` to validate endpoints. Test the dual-layer evaluation harness and ensure the controller's retry loops function as expected under failure conditions.
+
+## Phase 2: Orchestration and Script Validation (Weeks 4-6)
+* **Week 4 (Daily Ritual Tests)**: Test `scripts/daily_ritual.py`. Mock the `litellm` responses and assert that the regex-based parser correctly extracts data or gracefully defaults to the `MOCK_PAYLOAD` when necessary.
+* **Week 5 (Dashboard Generation Tests)**: Test HTML generation scripts (e.g., `generate_daily_index.py`). Use simple string matching or HTML parsers (like BeautifulSoup) in tests to ensure generated files contain the required JS arrays and masonry structures.
+* **Week 6 (Pre-existing Test Audit)**: Review the known broken tests (e.g., `test_v30_market_scanner.py`, `test_new_engines.py`). Decide strategically whether to fix them to align with the new architecture or safely remove them if the underlying code was purged.
+
+## Phase 3: Mock Ecosystem and Graceful Degradation (Weeks 7-9)
+* **Week 7 (Static Mock Mode Verification)**: Write integration tests that explicitly set `MOCK_MODE=true` and `ENV=demo`. Verify that all downstream components route requests to the `config/mocks/` directory instead of live APIs or Rust layers.
+* **Week 8 (Mock Connector Validation)**: Unit test the mock clients (e.g., `BigQueryConnector`, `LakehouseConnector`). Ensure they return appropriately structured Pydantic models rather than empty text stubs.
+* **Week 9 (Dynamic Search Hierarchy)**: Test the fallback mechanisms of the search agents. Simulate primary proxy failures (e.g., EDGAR delays) and assert that the agent successfully falls back to secondary proxies without hallucinating data.
+
+## Phase 4: Frontend UI and E2E Verification (Weeks 10-12)
+* **Week 10 (Playwright Setup & Smoke Tests)**: Implement Playwright to verify static HTML frontend changes. Write basic smoke tests that load local files (`file://`) and assert that critical UI elements render without errors.
+* **Week 11 (Interactive Workflow Tests)**: Use Playwright to test the 3-stage interactive illiquid market maker dashboard in `MarketMayhem.tsx` (Directory -> Tearsheet -> Pricing Drill-Down).
+* **Week 12 (Gated Content & CI Validation)**: Test the gated insider access UI mechanism, ensuring the blur effect toggles correctly upon authentication. Finalize the test suite, ensure clean execution via `uv run pytest`, and integrate seamlessly into the CI pipeline.

--- a/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_thursday.md
+++ b/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_thursday.md
@@ -1,0 +1,23 @@
+# Thursday Execution Plan: The Modernizer (Syntax & Framework Upgrades)
+
+**Objective**: Apply "The Modernizer" sequentially across all major repository domains over a 12-week timeline. Bring code up to date with the absolute latest language features, idioms, and tooling standards.
+
+## Phase 1: Python 3.10+ and Tooling Alignment (Weeks 1-3)
+* **Week 1 (Syntax Upgrades)**: Run `uv run ruff check --fix .` globally. Manually upgrade complex conditional chains in `core/` and `backend/` to utilize Python 3.10 Structural Pattern Matching (`match`/`case`).
+* **Week 2 (Type Hinting Modernization)**: Sweep all Python domains. Replace outdated `typing` imports (e.g., `List`, `Dict`, `Optional`) with modern built-in equivalents (`list`, `dict`, `str | None`). Enforce strict `mypy` compliance.
+* **Week 3 (Dependency Management)**: Eradicate legacy `setup.py` and `requirements.txt` logic. Ensure all deployment scripts and CI pipelines strictly use `uv` and `pyproject.toml` as the sole source of truth.
+
+## Phase 2: Framework Upgrades (Weeks 4-6)
+* **Week 4 (Pydantic V2 Migration)**: Review all data models in `backend/` and `core/`. Ensure full compliance with Pydantic V2 (replacing `.dict()` with `.model_dump()`, updating validators, etc.).
+* **Week 5 (FastAPI Idioms)**: Update `backend/api.py`. Adopt the latest FastAPI Dependency Injection idioms (e.g., using `Annotated`) and ensure complete OpenAPI schema generation for all endpoints.
+* **Week 6 (LLM Framework Alignment)**: Review integration with the `litellm` framework (e.g., in `scripts/daily_ritual.py`). Ensure dynamic multi-model fallbacks are using the most current, non-deprecated API methods.
+
+## Phase 3: Frontend and UI Modernization (Weeks 7-9)
+* **Week 7 (React & TypeScript Upgrades)**: Target `services/webapp/client/`. Ensure the project uses modern React functional components and Hooks exclusively. Address legacy peer dependencies (using `--legacy-peer-deps` during `npm install` if necessary).
+* **Week 8 (CSS & Styling)**: Modernize the styling approach. Ensure the 'Bloomberg Terminal meets Cyberpunk' aesthetic is implemented using modern CSS variables or utility classes (e.g., Tailwind, if applicable) rather than inline styles.
+* **Week 9 (Build Tools)**: Review the frontend build pipeline. If using legacy tools (like an old Webpack config), evaluate the feasibility of upgrading to modern, faster bundlers (like Vite), provided it doesn't break the static HTML generation requirements.
+
+## Phase 4: Scripting and Orchestration Modernization (Weeks 10-12)
+* **Week 10 (Bash Script Modernization)**: Review `.sh` scripts in the root and `docker/`. Ensure they use modern POSIX-compliant syntax, handle errors gracefully (`set -e`), and utilize `uv run` prefixes correctly.
+* **Week 11 (Docker Configuration)**: Update `docker/docker-compose.yml` and related Dockerfiles. Ensure they use modern multi-stage builds, current base images, and optimal caching strategies.
+* **Week 12 (Global Idiom Review)**: Conduct a final pass to ensure modern Python idioms (e.g., walrus operator `:=`, advanced comprehensions) are utilized where they genuinely improve readability without adding undue complexity.

--- a/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_tuesday.md
+++ b/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_tuesday.md
@@ -1,0 +1,23 @@
+# Tuesday Execution Plan: The Refactor (Global Modularity Initiative)
+
+**Objective**: Apply "The Refactor" sequentially across all major repository domains over a 12-week timeline. Reorganize code for high modularity, strict architectural boundaries, and adherence to modern best practices.
+
+## Phase 1: Backend and Execution Routing (Weeks 1-3)
+* **Week 1 (API & Core Decoupling)**: Refactor `backend/api.py`. Extract complex business logic into dedicated service layers (`backend/services/`), leaving the API layer strictly for HTTP routing and Pydantic validation.
+* **Week 2 (Engine Factory Design)**: Review `core/engine/factory.py`. Strengthen the boundary and Dependency Injection patterns between the `RealTradingEngine` (Rust) and the `LiveMockEngine` (Python fallback).
+* **Week 3 (Swarm Orchestration)**: Refactor `core/v30_architecture/python_intelligence/agents/swarm_runner.py`. Ensure asynchronous task management uses strong references and scalable Event-Driven patterns (e.g., LangGraph or queue structures).
+
+## Phase 2: System Interfaces and Connectors (Weeks 4-6)
+* **Week 4 (Mock Institutional Infrastructure)**: Refactor mock data providers. Ensure strict Dependency Injection is used to allow seamless switching between live APIs and the static Python proxies in `config/mocks/`.
+* **Week 5 (Rust/Python Bridge)**: Review the PyO3 integration in `core/rust_pricing/`. Refactor the interface to ensure clean, typed data handoffs between the Python backend and the computationally heavy Rust layer.
+* **Week 6 (Data Ingestion Modularity)**: Refactor data ingestion scripts in `scripts/`. Abstract repetitive file parsing logic into a shared `utils/data_parser.py` module to service multiple generation pipelines.
+
+## Phase 3: Frontend Architecture (Weeks 7-9)
+* **Week 7 (React Component Abstraction)**: Target `services/webapp/client/`. Abstract repetitive UI elements (e.g., masonry cards in `MarketMayhem.tsx`) into reusable, styled sub-components.
+* **Week 8 (Type Contract Alignment)**: Enforce strict contract boundaries. Refactor TypeScript interfaces to perfectly mirror backend Pydantic models. Establish a shared schema definition process.
+* **Week 9 (State Management & Re-renders)**: Optimize frontend state. Refactor array stream filtering (e.g., hoisting `.toLowerCase()` outside `.filter()` loops) to prevent massive string allocation bottlenecks during React re-renders.
+
+## Phase 4: Prompts, Tests, and Standardization (Weeks 10-12)
+* **Week 10 (Prompt Hierarchy Structuring)**: Refactor the Adam Operational Prompt Library (`prompt_library/AOPL-v2.0/`). Organize domain-specific analytical prompts strictly into targeted subdirectories (e.g., `professional_outcomes/`).
+* **Week 11 (Test Modularity)**: Refactor `tests/`. Abstract repetitive setup logic into reusable `pytest` fixtures. Ensure test files are clearly separated by domain (unit, integration, mock-fallback validation).
+* **Week 12 (Global Idiom Alignment)**: Conduct a final cross-domain sweep. Ensure consistent absolute import structures (banning `sys.path.append`) and adherence to single-source-of-truth configuration via `pyproject.toml`.

--- a/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_wednesday.md
+++ b/prompt_library/AOPL-v2.0/professional_outcomes/refactoring_execution_plan_wednesday.md
@@ -1,0 +1,23 @@
+# Wednesday Execution Plan: The Optimizer (Performance & Security Hardening)
+
+**Objective**: Apply "The Optimizer" sequentially across all major repository domains over a 12-week timeline. Audit for bottlenecks, enforce resource safety, and secure the system against vulnerabilities.
+
+## Phase 1: Security and Network Safety (Weeks 1-3)
+* **Week 1 (Backend Security)**: Run `uv run bandit -r core services scripts -ll -x tests`. Resolve legitimate security warnings (e.g., B104 binding to `0.0.0.0` by restricting hosts to `127.0.0.1`). Avoid lazy `# nosec` suppressions.
+* **Week 2 (Dependency Auditing)**: Audit `pyproject.toml` and lockfiles for known vulnerabilities. Update packages via `uv` while ensuring compatibility with the legacy `docker-compose.yml` deployment pathways.
+* **Week 3 (Access Control & Gating)**: Review frontend UI mechanisms (e.g., the authentication modal `#authModal` in `showcase/adam_daily_hub.html`). Ensure gated insider access logic is securely implemented on the backend, not just visually blurred on the frontend.
+
+## Phase 2: Backend and Execution Efficiency (Weeks 4-6)
+* **Week 4 (Async Profiling)**: Profile `backend/api.py` and the v30 swarm runner. Identify blocking synchronous operations within the event loop and convert them to `async`/`await` for higher throughput.
+* **Week 5 (Memory Management)**: Audit long-running evaluation loops in `backend/controller.py`. Implement explicit resource cleanup (closing database/mock client connections) and prevent memory leaks from unreferenced tasks.
+* **Week 6 (Rust Execution Tuning)**: Profile the `core/rust_pricing/` execution layer. Optimize PyO3 data transfer structures to minimize serialization/deserialization overhead between Python and Rust.
+
+## Phase 3: Frontend and Data Rendering Optimization (Weeks 7-9)
+* **Week 7 (React Render Cycles)**: Profile `services/webapp/client`. Identify redundant re-renders in heavy components like `PromptAlpha.tsx`. Implement `React.memo` and optimize sorting operations (e.g., using `a.timestamp - b.timestamp` directly).
+* **Week 8 (Dashboard Generation Speed)**: Profile large scripts like `scripts/generate_daily_index.py`. Optimize regex parsing of JavaScript arrays in HTML files and implement parallel file processing to speed up dashboard generation.
+* **Week 9 (Asset Delivery)**: Audit `showcase/` HTML dashboards. Ensure heavy assets (like machine learning JSON blobs or large images) are loaded lazily or compressed to improve terminal rendering speed.
+
+## Phase 4: Reliability and Graceful Fallbacks (Weeks 10-12)
+* **Week 10 (Controller Resilience)**: Optimize the self-healing CLI controller (`backend/controller.py`). Implement exponential backoff for retry loops to prevent hammering mocked APIs or live endpoints during outages.
+* **Week 11 (Fallback Efficiency)**: Test the `MOCK_MODE=true` toggle. Ensure the transition to lightweight Python static proxies (`config/mocks/`) is instantaneous and does not incur unnecessary timeout delays from the primary Rust layer.
+* **Week 12 (Stress Testing)**: Simulate high-load concurrent requests against the optimized backend APIs. Monitor memory usage and ensure the application fails gracefully without crashing the core engine.

--- a/prompt_library/AOPL-v2.0/professional_outcomes/weekly_refactoring_schedule.md
+++ b/prompt_library/AOPL-v2.0/professional_outcomes/weekly_refactoring_schedule.md
@@ -1,0 +1,41 @@
+# Weekly Refactoring Schedule
+
+This is a highly effective approach. By feeding your codebase to an LLM in targeted, bite-sized chunks with specific objectives, you can systematically upgrade your repository without overwhelming the context window.
+Here is a weekly schedule of powerful, specialized prompts you can run daily against your code. Whenever you use these, paste the relevant prompt along with the specific files or modules you want to focus on that day.
+
+## Monday: The Pruning (Waste & Dead Code Removal)
+Goal: Strip out bloat, unused imports, and legacy logic to reduce context size and improve clarity.
+The Prompt:
+> "Analyze the attached codebase. Your task is to aggressively but safely prune this code. Identify and remove any dead code, unused variables, redundant functions, unneeded dependencies, and obsolete comments. Simplify overly complex or nested logic without altering the core behavior. Return the cleaned code and provide a bulleted summary of exactly what waste was removed and why."
+
+## Tuesday: The Refactor (Architecture & Modularity)
+Goal: Reorganize the code to be highly modular, making it easier for both humans and AI to read and expand upon.
+The Prompt:
+> "Review this code for adherence to modern software engineering best practices. Refactor the code to drastically improve modularity, readability, and maintainability. Abstract repetitive logic into reusable utility functions or classes. Suggest and implement structural changes or design patterns that make this codebase more robust and easier to scale. Return the refactored code."
+
+## Wednesday: The Optimizer (Performance & Safety)
+Goal: Ensure the code runs incredibly fast, handles resources properly, and is secure.
+The Prompt:
+> "Audit this code for performance bottlenecks, resource leaks, and potential security vulnerabilities. Optimize the logic for time and space complexity, ensuring efficient data handling and asynchronous operations where applicable. Fortify the error handling to ensure the application fails gracefully rather than crashing. Provide the optimized code and a brief explanation of the performance gains."
+
+## Thursday: The Modernizer (Upgrades & Syntax)
+Goal: Bring the code up to date with the absolute latest language features and framework standards.
+The Prompt:
+> "Examine this codebase and identify any areas that rely on outdated patterns, legacy syntax, or anti-patterns. Upgrade the code to utilize the absolute latest language features (e.g., modern ES6+ for JS, pattern matching in Python 3.10+, etc.). Ensure the code aligns with contemporary idioms for its language. Return the modernized code and note which new language features were implemented."
+
+## Friday: The Innovator (Cutting-Edge AI Integration)
+Goal: Build out functionality that leverages modern LLM capabilities, autonomous agents, or advanced APIs.
+The Prompt:
+> "Analyze the core purpose of this code. I want to upgrade this project by integrating cutting-edge AI capabilities (such as LLM calls, RAG pipelines, autonomous agent behaviors, or smart parsing). Brainstorm 3 specific, high-value AI features that could natively enhance this application. Then, write the production-ready implementation code for the best of those 3 ideas, ensuring it seamlessly integrates with my existing logic."
+
+## Saturday: The Documenter (Clarity & Onboarding)
+Goal: Ensure the refined code is perfectly documented so that future AI context windows can understand it instantly.
+The Prompt:
+> "Read through this updated code. Generate clean, concise, and highly informative inline documentation and docstrings for all major functions and classes. Then, write a comprehensive 'Architecture & Usage' section that I can append to my README. The documentation should be written in a way that helps another AI instantly understand the purpose, inputs, and outputs of this module."
+
+## Sunday: The Validator (Test Generation)
+Goal: Lock in your progress by ensuring everything works and won't break during next week's changes.
+The Prompt:
+> "Analyze this codebase and generate a comprehensive suite of unit and integration tests using a modern testing framework. Focus on testing the core logic, edge cases, and the error-handling mechanisms. Ensure the tests are highly readable and mock any external API calls or database connections. Return the complete test file."
+
+Pro-Tip for Execution: When you run these, don't just dump the whole repo in at once. Pick a specific feature, folder, or file (e.g., "Today I am running the Monday and Tuesday prompts on my database utility functions") and cycle through your repository systematically.


### PR DESCRIPTION
Expanded the 7 daily execution plans to cover 12 weeks of execution across all major parts of the repo as requested.

---
*PR created automatically by Jules for task [6193726533544006735](https://jules.google.com/task/6193726533544006735) started by @adamvangrover*