### PR TITLE
Migrate Matching Engine to High-Performance Rust Layer

### DIFF
--- a/core/quantitative/matching_engine.py
+++ b/core/quantitative/matching_engine.py
@@ -10,6 +10,13 @@ from core.unified_ledger.schema import ChildOrder, OrderSide, OrderType, Executi
 
 logger = logging.getLogger(__name__)
 
+try:
+    import rust_pricing
+    RUST_AVAILABLE = True
+except ImportError:
+    RUST_AVAILABLE = False
+    logger.warning("rust_pricing module not found. Falling back to pure Python implementation for MatchingEngine.")
+
 class OrderBook:
     def __init__(self, symbol: str):
         self.symbol = symbol
@@ -199,50 +206,90 @@ class OrderBook:
 class MatchingEngine:
     """
     Manages order books for multiple symbols.
+    Utilizes Rust bindings for deterministic, sub-millisecond execution if available.
     """
     def __init__(self):
-        self.books: Dict[str, OrderBook] = {}
+        if RUST_AVAILABLE:
+            try:
+                self.rust_engine = rust_pricing.RustMatchingEngine()
+                self.use_rust = True
+                logger.info("Successfully initialized RustMatchingEngine.")
+            except Exception as e:
+                logger.error(f"Failed to initialize RustMatchingEngine: {e}. Falling back to Python.")
+                self.use_rust = False
+                self.books: Dict[str, OrderBook] = {}
+        else:
+            self.use_rust = False
+            self.books: Dict[str, OrderBook] = {}
 
     def cancel_order(self, symbol: str, order_id: UUID) -> bool:
-        if symbol in self.books:
-            return self.books[symbol].cancel_order(order_id)
-        return False
+        if self.use_rust:
+            return self.rust_engine.cancel_order(symbol, str(order_id))
+        else:
+            if symbol in self.books:
+                return self.books[symbol].cancel_order(order_id)
+            return False
 
     def process_order(self, order: ChildOrder) -> Dict:
-        if order.symbol not in self.books:
-            self.books[order.symbol] = OrderBook(order.symbol)
+        if self.use_rust:
+            order_dict = {
+                "order_id": str(order.order_id),
+                "symbol": order.symbol,
+                "side": order.side.value,
+                "quantity": order.quantity,
+                "price": order.price,
+                "order_type": order.order_type.value,
+                "status": order.status,
+                "filled_quantity": order.filled_quantity,
+            }
+            try:
+                result = self.rust_engine.process_order(order_dict)
 
-        book = self.books[order.symbol]
-        fills = book.add_order(order)
+                # Update the original order object based on the result
+                order.status = result.get("status", order.status)
+                order.filled_quantity = result.get("filled_quantity", order.filled_quantity)
+                if "average_fill_price" in result:
+                    order.average_fill_price = result["average_fill_price"]
 
-        # Calculate average fill price
-        total_fill_cost = 0.0
-        total_fill_qty = 0.0
+                return result
+            except Exception as e:
+                logger.error(f"Rust process_order failed: {e}. Order not processed properly.")
+                raise e
+        else:
+            if order.symbol not in self.books:
+                self.books[order.symbol] = OrderBook(order.symbol)
 
-        processed_fills = []
+            book = self.books[order.symbol]
+            fills = book.add_order(order)
 
-        for matched_order, qty in fills:
-            price = matched_order.price # Limit price of maker
-            cost = price * qty
-            total_fill_cost += cost
-            total_fill_qty += qty
-            processed_fills.append({
-                "maker_order_id": str(matched_order.order_id),
-                "taker_order_id": str(order.order_id),
-                "price": price,
-                "quantity": qty,
-                "timestamp": datetime.utcnow().isoformat()
-            })
+            # Calculate average fill price
+            total_fill_cost = 0.0
+            total_fill_qty = 0.0
 
-        if total_fill_qty > 0:
-            avg_price = total_fill_cost / total_fill_qty
-            order.average_fill_price = avg_price
-            order.status = "FILLED" if order.filled_quantity >= order.quantity else "PARTIALLY_FILLED"
+            processed_fills = []
 
-        return {
-            "order_id": str(order.order_id),
-            "symbol": order.symbol,
-            "status": order.status,
-            "filled_quantity": order.filled_quantity,
-            "fills": processed_fills
-        }
+            for matched_order, qty in fills:
+                price = matched_order.price # Limit price of maker
+                cost = price * qty
+                total_fill_cost += cost
+                total_fill_qty += qty
+                processed_fills.append({
+                    "maker_order_id": str(matched_order.order_id),
+                    "taker_order_id": str(order.order_id),
+                    "price": price,
+                    "quantity": qty,
+                    "timestamp": datetime.utcnow().isoformat()
+                })
+
+            if total_fill_qty > 0:
+                avg_price = total_fill_cost / total_fill_qty
+                order.average_fill_price = avg_price
+                order.status = "FILLED" if order.filled_quantity >= order.quantity else "PARTIALLY_FILLED"
+
+            return {
+                "order_id": str(order.order_id),
+                "symbol": order.symbol,
+                "status": order.status,
+                "filled_quantity": order.filled_quantity,
+                "fills": processed_fills
+            }

--- a/core/rust_pricing/src/lib.rs
+++ b/core/rust_pricing/src/lib.rs
@@ -1,9 +1,11 @@
 use pyo3::prelude::*;
 
 mod pricing;
-use pricing::{MarketParams, calculate_quotes};
+mod matching;
 
-#[pyfunction]
+use pricing::{MarketParams, calculate_quotes};
+use matching::RustMatchingEngine;
+
 /// Calculates market quotes based on provided market parameters and liquidity mechanics.
 /// Exposes functionality to the Python layer via PyO3.
 #[pyfunction]
@@ -22,5 +24,6 @@ fn get_quotes(mid_price: f64, volatility: f64, inventory: f64, risk_aversion: f6
 #[pymodule]
 fn rust_pricing(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_quotes, m)?)?;
+    m.add_class::<RustMatchingEngine>()?;
     Ok(())
 }

--- a/core/rust_pricing/src/matching.rs
+++ b/core/rust_pricing/src/matching.rs
@@ -1,0 +1,368 @@
+use pyo3::prelude::*;
+use pyo3::types::{PyDict, PyList};
+use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::cmp::Ordering;
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Copy, PartialEq, PartialOrd)]
+pub struct OrderedFloat(pub f64);
+
+impl Eq for OrderedFloat {}
+
+impl Ord for OrderedFloat {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other).unwrap_or(Ordering::Equal)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RustOrder {
+    pub order_id: String,
+    pub symbol: String,
+    pub side: String,
+    pub quantity: f64,
+    pub price: Option<f64>,
+    pub order_type: String,
+    pub status: String,
+    pub filled_quantity: f64,
+}
+
+type OrderRef = Arc<Mutex<RustOrder>>;
+
+pub struct RustOrderBook {
+    pub symbol: String,
+    pub bids_levels: BTreeMap<OrderedFloat, VecDeque<OrderRef>>,
+    pub asks_levels: BTreeMap<OrderedFloat, VecDeque<OrderRef>>,
+    pub order_map: HashMap<String, OrderRef>,
+}
+
+impl RustOrderBook {
+    pub fn new(symbol: String) -> Self {
+        Self {
+            symbol,
+            bids_levels: BTreeMap::new(),
+            asks_levels: BTreeMap::new(),
+            order_map: HashMap::new(),
+        }
+    }
+
+    pub fn cancel_order(&mut self, order_id: &str) -> bool {
+        if let Some(order) = self.order_map.remove(order_id) {
+            order.lock().unwrap().status = "CANCELED".to_string();
+            return true;
+        }
+        false
+    }
+
+    pub fn add_order(&mut self, mut incoming_order: RustOrder) -> Vec<(OrderRef, f64)> {
+        let mut fills = Vec::new();
+        let mut remaining_qty = incoming_order.quantity;
+
+        if incoming_order.side == "BUY" {
+            let mut prices_to_remove = Vec::new();
+
+            for (&price_key, level_queue) in self.asks_levels.iter_mut() {
+                if remaining_qty <= 0.0 {
+                    break;
+                }
+
+                if incoming_order.order_type == "LIMIT" {
+                    if let Some(limit_price) = incoming_order.price {
+                        if price_key.0 > limit_price {
+                            break;
+                        }
+                    }
+                }
+
+                let mut orders_to_remove = 0;
+                for best_ask_ref in level_queue.iter_mut() {
+                    if remaining_qty <= 0.0 {
+                        break;
+                    }
+
+                    let mut best_ask_order = best_ask_ref.lock().unwrap();
+                    if best_ask_order.status == "CANCELED" {
+                        orders_to_remove += 1;
+                        continue;
+                    }
+
+                    let available_qty = best_ask_order.quantity - best_ask_order.filled_quantity;
+                    let match_qty = if remaining_qty < available_qty { remaining_qty } else { available_qty };
+
+                    fills.push((Arc::clone(best_ask_ref), match_qty));
+
+                    best_ask_order.filled_quantity += match_qty;
+                    incoming_order.filled_quantity += match_qty;
+                    remaining_qty -= match_qty;
+
+                    if best_ask_order.filled_quantity >= best_ask_order.quantity {
+                        orders_to_remove += 1;
+                        self.order_map.remove(&best_ask_order.order_id);
+                    }
+                }
+
+                for _ in 0..orders_to_remove {
+                    level_queue.pop_front();
+                }
+                if level_queue.is_empty() {
+                    prices_to_remove.push(price_key);
+                }
+            }
+
+            for p in prices_to_remove {
+                self.asks_levels.remove(&p);
+            }
+
+            if remaining_qty > 0.0 && incoming_order.order_type == "LIMIT" {
+                self._add_bid(incoming_order);
+            }
+
+        } else if incoming_order.side == "SELL" {
+            let mut prices_to_remove = Vec::new();
+
+            for (&price_key, level_queue) in self.bids_levels.iter_mut().rev() {
+                if remaining_qty <= 0.0 {
+                    break;
+                }
+
+                if incoming_order.order_type == "LIMIT" {
+                    if let Some(limit_price) = incoming_order.price {
+                        if price_key.0 < limit_price {
+                            break;
+                        }
+                    }
+                }
+
+                let mut orders_to_remove = 0;
+                for best_bid_ref in level_queue.iter_mut() {
+                    if remaining_qty <= 0.0 {
+                        break;
+                    }
+
+                    let mut best_bid_order = best_bid_ref.lock().unwrap();
+                    if best_bid_order.status == "CANCELED" {
+                        orders_to_remove += 1;
+                        continue;
+                    }
+
+                    let available_qty = best_bid_order.quantity - best_bid_order.filled_quantity;
+                    let match_qty = if remaining_qty < available_qty { remaining_qty } else { available_qty };
+
+                    fills.push((Arc::clone(best_bid_ref), match_qty));
+
+                    best_bid_order.filled_quantity += match_qty;
+                    incoming_order.filled_quantity += match_qty;
+                    remaining_qty -= match_qty;
+
+                    if best_bid_order.filled_quantity >= best_bid_order.quantity {
+                        orders_to_remove += 1;
+                        self.order_map.remove(&best_bid_order.order_id);
+                    }
+                }
+
+                for _ in 0..orders_to_remove {
+                    level_queue.pop_front();
+                }
+                if level_queue.is_empty() {
+                    prices_to_remove.push(price_key);
+                }
+            }
+
+            for p in prices_to_remove {
+                self.bids_levels.remove(&p);
+            }
+
+            if remaining_qty > 0.0 && incoming_order.order_type == "LIMIT" {
+                self._add_ask(incoming_order);
+            }
+        }
+
+        fills
+    }
+
+    fn _add_bid(&mut self, order: RustOrder) {
+        if let Some(price) = order.price {
+            let order_id = order.order_id.clone();
+            let order_ref = Arc::new(Mutex::new(order));
+            self.bids_levels.entry(OrderedFloat(price)).or_insert_with(VecDeque::new).push_back(Arc::clone(&order_ref));
+            self.order_map.insert(order_id, order_ref);
+        }
+    }
+
+    fn _add_ask(&mut self, order: RustOrder) {
+        if let Some(price) = order.price {
+            let order_id = order.order_id.clone();
+            let order_ref = Arc::new(Mutex::new(order));
+            self.asks_levels.entry(OrderedFloat(price)).or_insert_with(VecDeque::new).push_back(Arc::clone(&order_ref));
+            self.order_map.insert(order_id, order_ref);
+        }
+    }
+
+    pub fn get_l2_snapshot(&mut self, py: Python, depth: usize) -> PyResult<PyObject> {
+        let bids = PyList::empty(py);
+        let mut count = 0;
+
+        for (&price_key, level_queue) in self.bids_levels.iter().rev() {
+            if count >= depth { break; }
+            let mut qty = 0.0;
+            for order_ref in level_queue.iter() {
+                let order = order_ref.lock().unwrap();
+                if order.status != "CANCELED" {
+                    qty += order.quantity - order.filled_quantity;
+                }
+            }
+            if qty > 0.0 {
+                let tuple = pyo3::types::PyTuple::new(py, &[price_key.0, qty]);
+                bids.append(tuple)?;
+                count += 1;
+            }
+        }
+
+        let asks = PyList::empty(py);
+        count = 0;
+        for (&price_key, level_queue) in self.asks_levels.iter() {
+            if count >= depth { break; }
+            let mut qty = 0.0;
+            for order_ref in level_queue.iter() {
+                let order = order_ref.lock().unwrap();
+                if order.status != "CANCELED" {
+                    qty += order.quantity - order.filled_quantity;
+                }
+            }
+            if qty > 0.0 {
+                let tuple = pyo3::types::PyTuple::new(py, &[price_key.0, qty]);
+                asks.append(tuple)?;
+                count += 1;
+            }
+        }
+
+        let result = PyDict::new(py);
+        result.set_item("symbol", &self.symbol)?;
+        result.set_item("bids", bids)?;
+        result.set_item("asks", asks)?;
+
+        Ok(result.into())
+    }
+}
+
+#[pyclass]
+pub struct RustMatchingEngine {
+    books: HashMap<String, RustOrderBook>,
+}
+
+#[pymethods]
+impl RustMatchingEngine {
+    #[new]
+    pub fn new() -> Self {
+        Self {
+            books: HashMap::new(),
+        }
+    }
+
+    pub fn cancel_order(&mut self, symbol: &str, order_id: &str) -> bool {
+        if let Some(book) = self.books.get_mut(symbol) {
+            return book.cancel_order(order_id);
+        }
+        false
+    }
+
+    pub fn process_order<'py>(&mut self, py: Python<'py>, order_dict: &'py PyDict) -> PyResult<&'py PyDict> {
+        let order_id: String = order_dict.get_item("order_id").unwrap().extract()?;
+        let symbol: String = order_dict.get_item("symbol").unwrap().extract()?;
+        let side: String = order_dict.get_item("side").unwrap().extract()?;
+        let quantity: f64 = order_dict.get_item("quantity").unwrap().extract()?;
+
+        let price_item = order_dict.get_item("price");
+        let price: Option<f64> = match price_item {
+            Some(p) => if p.is_none() { None } else { Some(p.extract()?) },
+            None => None,
+        };
+
+        let order_type: String = order_dict.get_item("order_type").unwrap().extract()?;
+
+        let status_item = order_dict.get_item("status");
+        let status: String = if let Some(s) = status_item { s.extract()? } else { "PENDING".to_string() };
+
+        let fq_item = order_dict.get_item("filled_quantity");
+        let filled_quantity: f64 = if let Some(fq) = fq_item { fq.extract()? } else { 0.0 };
+
+        let mut incoming_order = RustOrder {
+            order_id: order_id.clone(),
+            symbol: symbol.clone(),
+            side,
+            quantity,
+            price,
+            order_type,
+            status,
+            filled_quantity,
+        };
+
+        let book = self.books.entry(symbol.clone()).or_insert_with(|| RustOrderBook::new(symbol.clone()));
+
+        let fills = book.add_order(incoming_order.clone());
+
+        let mut total_fill_cost = 0.0;
+        let mut total_fill_qty = 0.0;
+        let processed_fills = PyList::empty(py);
+
+        let datetime_module = py.import("datetime")?;
+        let datetime_class = datetime_module.getattr("datetime")?;
+
+        for (matched_ref, match_qty) in fills {
+            let matched_order = matched_ref.lock().unwrap();
+            let matched_price = matched_order.price.unwrap_or(0.0);
+
+            let cost = matched_price * match_qty;
+            total_fill_cost += cost;
+            total_fill_qty += match_qty;
+
+            let fill_dict = PyDict::new(py);
+            fill_dict.set_item("maker_order_id", &matched_order.order_id)?;
+            fill_dict.set_item("taker_order_id", &order_id)?;
+            fill_dict.set_item("price", matched_price)?;
+            fill_dict.set_item("quantity", match_qty)?;
+
+            let utcnow = datetime_class.getattr("utcnow")?.call0()?;
+            let isoformat = utcnow.getattr("isoformat")?.call0()?;
+            fill_dict.set_item("timestamp", isoformat)?;
+
+            processed_fills.append(fill_dict)?;
+        }
+
+        if total_fill_qty > 0.0 {
+            incoming_order.filled_quantity += total_fill_qty;
+        }
+
+        let new_status = if incoming_order.filled_quantity >= incoming_order.quantity {
+            "FILLED"
+        } else {
+            if incoming_order.filled_quantity > 0.0 { "PARTIALLY_FILLED" } else { "PENDING" }
+        };
+
+        let result_dict = PyDict::new(py);
+        result_dict.set_item("order_id", order_id)?;
+        result_dict.set_item("symbol", symbol)?;
+        result_dict.set_item("status", new_status)?;
+        result_dict.set_item("filled_quantity", incoming_order.filled_quantity)?;
+        result_dict.set_item("fills", processed_fills)?;
+
+        if total_fill_qty > 0.0 {
+            let avg_price = total_fill_cost / total_fill_qty;
+            result_dict.set_item("average_fill_price", avg_price)?;
+        }
+
+        Ok(result_dict)
+    }
+
+    pub fn get_l2_snapshot(&mut self, py: Python, symbol: &str, depth: usize) -> PyResult<PyObject> {
+        if let Some(book) = self.books.get_mut(symbol) {
+            book.get_l2_snapshot(py, depth)
+        } else {
+            let result = PyDict::new(py);
+            result.set_item("symbol", symbol)?;
+            result.set_item("bids", PyList::empty(py))?;
+            result.set_item("asks", PyList::empty(py))?;
+            Ok(result.into())
+        }
+    }
+}

--- a/tests/test_matching_engine.py
+++ b/tests/test_matching_engine.py
@@ -1,0 +1,89 @@
+import unittest
+from uuid import uuid4
+from datetime import datetime
+from core.quantitative.matching_engine import MatchingEngine, OrderBook, RUST_AVAILABLE
+from core.unified_ledger.schema import ChildOrder, OrderSide, OrderType, ExecutionVenue
+
+class TestMatchingEngine(unittest.TestCase):
+    def setUp(self):
+        self.engine = MatchingEngine()
+
+    def test_initialization(self):
+        self.assertIsNotNone(self.engine)
+        if RUST_AVAILABLE:
+            self.assertTrue(self.engine.use_rust)
+        else:
+            self.assertFalse(self.engine.use_rust)
+
+    def test_process_order(self):
+        order1 = ChildOrder(
+            parent_id=uuid4(),
+            symbol="AAPL",
+            side=OrderSide.BUY,
+            quantity=100,
+            price=150.0,
+            order_type=OrderType.LIMIT,
+            venue=ExecutionVenue.INTERNAL,
+            desk_id="DESK1"
+        )
+
+        result1 = self.engine.process_order(order1)
+        self.assertEqual(result1["status"], "PENDING")
+        self.assertEqual(result1["filled_quantity"], 0.0)
+
+        order2 = ChildOrder(
+            parent_id=uuid4(),
+            symbol="AAPL",
+            side=OrderSide.SELL,
+            quantity=50,
+            price=149.0,
+            order_type=OrderType.LIMIT,
+            venue=ExecutionVenue.INTERNAL,
+            desk_id="DESK2"
+        )
+
+        result2 = self.engine.process_order(order2)
+        self.assertEqual(result2["status"], "FILLED")
+        self.assertEqual(result2["filled_quantity"], 50.0)
+        self.assertEqual(len(result2["fills"]), 1)
+
+        # In this specific test, order1 (BUY 150) should be resting.
+        # order2 (SELL 149) should match against order1 at 150.
+        self.assertEqual(result2["fills"][0]["price"], 150.0)
+
+    def test_cancel_order(self):
+        order = ChildOrder(
+            parent_id=uuid4(),
+            symbol="MSFT",
+            side=OrderSide.BUY,
+            quantity=100,
+            price=300.0,
+            order_type=OrderType.LIMIT,
+            venue=ExecutionVenue.INTERNAL,
+            desk_id="DESK1"
+        )
+
+        self.engine.process_order(order)
+
+        # Test cancellation
+        success = self.engine.cancel_order("MSFT", order.order_id)
+        self.assertTrue(success)
+
+        # Try to match against cancelled order
+        order2 = ChildOrder(
+            parent_id=uuid4(),
+            symbol="MSFT",
+            side=OrderSide.SELL,
+            quantity=50,
+            price=299.0,
+            order_type=OrderType.LIMIT,
+            venue=ExecutionVenue.INTERNAL,
+            desk_id="DESK2"
+        )
+
+        result2 = self.engine.process_order(order2)
+        self.assertEqual(result2["status"], "PENDING")
+        self.assertEqual(result2["filled_quantity"], 0.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR addresses the performance constraints in the Python-based execution layer by deeply integrating a high-performance matching engine written natively in Rust.

Previously, `core/rust_pricing/` was limited to a single pure math calculation. This patch expands its scope to encompass complex state management (OrderBooks) and iterating over bid/ask arrays natively in Rust, achieving significant throughput optimization.

Key changes:
1. **Rust Engine Development**: Implemented the matching engine (`matching.rs`) using robust `BTreeMap` structures for O(log N) price level insertion and `Arc<Mutex>` for thread safety across the PyO3 boundary.
2. **Graceful Fallback**: The Python `MatchingEngine` class dynamically detects the presence of the compiled `rust_pricing` module. If missing or if an initialization error occurs, it silently falls back to the original pure Python logic.
3. **Data Integrity**: Ensure the order statuses and populated fields are correctly propagated back from the Rust return `PyDict` into the Python `ChildOrder` objects.

All unit tests execute successfully.

---
*PR created automatically by Jules for task [15183783159427727974](https://jules.google.com/task/15183783159427727974) started by @adamvangrover*