### PR TITLE
Add Master Repository Upgrade Prompt template and phases

### DIFF
--- a/prompt_library/AOPL-v2.0/tasks/Master_Repository_Upgrade_Prompt.md
+++ b/prompt_library/AOPL-v2.0/tasks/Master_Repository_Upgrade_Prompt.md
@@ -1,0 +1,41 @@
+You are an expert Software Architect and Senior Developer. I am systematically upgrading my entire codebase by feeding it to you in targeted, bite-sized chunks.
+
+Your objective is to drastically refine, upgrade, and optimize the attached code by running it through a strict 7-phase enhancement cycle. Do not alter the core business logic or break existing integrations, but significantly improve how the code operates.
+
+Please apply the following 7 phases sequentially to the provided code:
+
+1. THE PRUNING (Waste Removal)
+Aggressively but safely prune the code. Remove dead code, unused variables/imports, unneeded dependencies, and obsolete comments. Simplify overly complex or nested logic.
+
+2. THE REFACTOR (Architecture & Modularity)
+Reorganize the code to adhere to modern best practices. Improve modularity and readability. Abstract repetitive logic into reusable utility functions or classes, and apply structural design patterns that make it robust and scalable.
+
+3. THE OPTIMIZER (Performance & Safety)
+Audit for bottlenecks, resource leaks, and security vulnerabilities. Optimize for time and space complexity. Fortify error handling to ensure the application fails gracefully.
+
+4. THE MODERNIZER (Upgrades & Syntax)
+Upgrade the code to utilize the absolute latest language features and framework standards (e.g., modern ES6+, Python 3.10+ pattern matching). Replace outdated patterns and anti-patterns with contemporary idioms.
+
+5. THE INNOVATOR (Advanced Capabilities)
+Identify where this code could benefit from cutting-edge features (e.g., smart parsing, autonomous logic, or lightweight AI/LLM integrations). If applicable, seamlessly integrate the most high-value enhancement into the logic.
+
+6. THE DOCUMENTER (Clarity & AI-Readability)
+Generate clean, highly informative inline documentation and docstrings. Write them specifically so that future AI context windows can instantly understand the module's purpose, inputs, and outputs.
+
+7. THE VALIDATOR (Test Generation)
+Generate a comprehensive suite of unit and integration tests using a modern testing framework. Focus on core logic, edge cases, and error-handling. Mock external calls where necessary.
+
+OUTPUT FORMAT:
+Do not output the code 7 different times. Instead, process it internally and provide:
+1. "Changelog:" A brief, bulleted summary of the specific improvements made during the 7 phases.
+2. "Upgraded Code:" The final, consolidated, production-ready code.
+3. "Test Suite:" The complete, ready-to-run testing file for the upgraded code.
+
+Here is the code to process today:
+[INSERT YOUR CODE/FILE HERE]
+
+How to execute this systematically
+If you want to automate this over time, here is how you structure your workflow:
+ * Map the Repo: Generate a list of all your target files (e.g., find src -type f -name "*.py").
+ * Prioritize: Start with foundational files (utilities, database connections, schemas) before moving to higher-level routing or UI components. You want the foundation upgraded before the things that rely on it are upgraded.
+ * Pace Yourself: If doing this manually, do 1 to 3 files a day. Review the output, commit the changes, and test your app to ensure the LLM didn't hallucinate a breaking change.

--- a/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Documenter.md
+++ b/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Documenter.md
@@ -1,0 +1,13 @@
+## Phase 6: THE DOCUMENTER (Clarity & AI-Readability)
+**Objective**: Generate clean, highly informative inline documentation and docstrings. Write them specifically so that future AI context windows can instantly understand the module's purpose, inputs, and outputs.
+
+### Instructions:
+1.  **Module-Level Docstring**: Write a comprehensive docstring at the top of the file explaining the module's overall purpose, its role in the larger system, and any critical dependencies or assumptions.
+2.  **Class/Function Docstrings**: Every public class, method, and function must have a docstring. Use a standard format (e.g., Google or Sphinx style in Python). Include:
+    *   A brief summary of what it does.
+    *   `Args:` (or equivalent) listing every parameter, its type, and its purpose.
+    *   `Returns:` detailing the return type and what it represents.
+    *   `Raises:` listing specific exceptions that might be thrown and under what conditions.
+3.  **AI-Optimized Context**: Phrase docstrings clearly and concisely. Avoid jargon where plain English suffices. State the *intent* ("Why are we doing this?") alongside the mechanism ("What are we doing?").
+4.  **Inline Comments**: Use inline comments sparingly, only to explain *complex, non-obvious, or tricky* pieces of logic that cannot be simplified. If you find yourself writing a long inline comment, consider if the code itself needs refactoring (Phase 2).
+5.  **Review Format**: Ensure consistency in formatting across all documentation within the file.

--- a/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Innovator.md
+++ b/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Innovator.md
@@ -1,0 +1,13 @@
+## Phase 5: THE INNOVATOR (Advanced Capabilities)
+**Objective**: Identify where this code could benefit from cutting-edge features (e.g., smart parsing, autonomous logic, or lightweight AI/LLM integrations). If applicable, seamlessly integrate the most high-value enhancement into the logic.
+
+### Instructions:
+1.  **Analyze Potential**: Review the module's core purpose. Does it process natural language? Does it make complex routing decisions? Does it handle fuzzy data?
+2.  **Select Enhancements**: Choose ONE high-value, low-risk innovation to integrate. Examples:
+    *   Replacing rigid regex parsing with a lightweight, local ML model or a structured LLM call (if appropriate within the system context).
+    *   Adding adaptive or dynamic routing logic instead of static `if/else` chains.
+    *   Implementing smart caching or predictive pre-fetching based on usage patterns.
+    *   Adding semantic search capabilities using embeddings.
+3.  **Implement Safely**: Integrate the innovation *without* breaking existing contracts. If adding an external dependency (like an LLM call), wrap it in robust fallback logic (e.g., try the LLM, fall back to the old deterministic method on failure).
+4.  **Document the Innovation**: Clearly document why this feature was added and how it improves the system.
+5.  **Verify Tests**: Write tests specifically for the new innovative capability and ensure the fallback logic works when the innovation is disabled or fails.

--- a/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Modernizer.md
+++ b/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Modernizer.md
@@ -1,0 +1,10 @@
+## Phase 4: THE MODERNIZER (Upgrades & Syntax)
+**Objective**: Upgrade the code to utilize the absolute latest language features and framework standards (e.g., modern ES6+, Python 3.10+ pattern matching). Replace outdated patterns and anti-patterns with contemporary idioms.
+
+### Instructions:
+1.  **Language Features**: Apply the latest stable syntax features of the target language. For Python (if applicable), this might include f-strings, type hinting (`typing` module or modern built-in generics), structural pattern matching (`match`/`case`), or walrus operators (`:=`).
+2.  **Type Safety**: Add comprehensive type annotations to all function signatures, class attributes, and complex variables. This improves readability and enables static analysis tools (like mypy or TypeScript compiler).
+3.  **Modern Idioms**: Replace clunky or verbose constructs with elegant, idiomatic solutions (e.g., list comprehensions instead of loops for simple mapping/filtering, `dataclasses` or Pydantic models instead of standard classes for data containers).
+4.  **Framework Updates**: If the code uses a framework (like React, FastAPI, Django), ensure it uses the latest recommended patterns (e.g., Hooks instead of Class components, Dependency Injection, Async/Await where appropriate).
+5.  **Remove Deprecated APIs**: Identify and replace any calls to libraries or internal APIs that have been marked as deprecated.
+6.  **Verify Tests**: Run static type checkers and the full test suite to ensure the modernizations haven't introduced regressions.

--- a/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Optimizer.md
+++ b/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Optimizer.md
@@ -1,0 +1,10 @@
+## Phase 3: THE OPTIMIZER (Performance & Safety)
+**Objective**: Audit for bottlenecks, resource leaks, and security vulnerabilities. Optimize for time and space complexity. Fortify error handling to ensure the application fails gracefully.
+
+### Instructions:
+1.  **Algorithmic Optimization**: Review loops, sorting, and search operations. Can the time complexity (Big O) be improved (e.g., changing O(N^2) to O(N log N) or O(N))? Can space complexity be reduced?
+2.  **Resource Management**: Check for potential resource leaks (e.g., unclosed files, network connections, database cursors). Ensure proper use of context managers (e.g., `with` statements in Python).
+3.  **Security Audit**: Scan for common vulnerabilities. Are inputs properly validated and sanitized? Are database queries safe from injection (e.g., using parameterized queries)? Are sensitive data handled securely?
+4.  **Error Handling**: Replace broad `try-except` blocks with specific exception catching. Ensure that errors are logged meaningfully and that the application degrades or fails gracefully without exposing internal state or crashing abruptly.
+5.  **Caching/Memoization**: Introduce caching mechanisms for expensive or frequently called functions if appropriate.
+6.  **Verify Tests**: Add new tests to specifically target the fortified error handling and edge cases. Run the full suite.

--- a/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Pruning.md
+++ b/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Pruning.md
@@ -1,0 +1,10 @@
+## Phase 1: THE PRUNING (Waste Removal)
+**Objective**: Aggressively but safely prune the code. Remove dead code, unused variables/imports, unneeded dependencies, and obsolete comments. Simplify overly complex or nested logic.
+
+### Instructions:
+1.  **Analyze Imports**: Review all import statements. Remove any that are not actively used within the module.
+2.  **Identify Dead Code**: Find and remove functions, classes, or methods that are never called or instantiated within the project (unless they are explicitly part of a public API intended for external use).
+3.  **Remove Unused Variables**: Delete any variables that are assigned but never read.
+4.  **Clean Up Comments**: Remove commented-out code, redundant comments that just restate the code, and obsolete or misleading comments.
+5.  **Simplify Logic**: Look for deeply nested `if/else` statements, complex boolean expressions, or convoluted loops. Refactor them into flatter, simpler, and more direct logic. Use guard clauses to reduce nesting.
+6.  **Verify Tests**: Ensure that after pruning, the existing test suite still passes without modification (or with minimal modifications if tests relied on pruned internal details).

--- a/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Refactor.md
+++ b/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Refactor.md
@@ -1,0 +1,10 @@
+## Phase 2: THE REFACTOR (Architecture & Modularity)
+**Objective**: Reorganize the code to adhere to modern best practices. Improve modularity and readability. Abstract repetitive logic into reusable utility functions or classes, and apply structural design patterns that make it robust and scalable.
+
+### Instructions:
+1.  **Extract Repetitive Logic**: Identify code blocks that are repeated multiple times (DRY principle). Extract them into standalone utility functions, helper methods, or separate classes.
+2.  **Improve Cohesion**: Ensure that each class or function has a single, well-defined responsibility (Single Responsibility Principle). If a module does too many things, split it up.
+3.  **Enhance Modularity**: Organize the code into logical groupings (e.g., separating data access, business logic, and presentation/API layers). Use clear interfaces or abstract base classes if appropriate to define boundaries.
+4.  **Apply Design Patterns**: Look for opportunities to apply established structural design patterns (e.g., Factory, Strategy, Observer, Decorator) if they genuinely simplify the design and improve scalability without over-engineering.
+5.  **Rename for Clarity**: Rename variables, functions, and classes to be highly descriptive of their purpose and behavior. Favor clarity over brevity.
+6.  **Verify Tests**: Update existing tests to reflect the new structure. Ensure all tests pass.

--- a/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Validator.md
+++ b/prompt_library/AOPL-v2.0/tasks/upgrade_modules/Validator.md
@@ -1,0 +1,11 @@
+## Phase 7: THE VALIDATOR (Test Generation)
+**Objective**: Generate a comprehensive suite of unit and integration tests using a modern testing framework. Focus on core logic, edge cases, and error-handling. Mock external calls where necessary.
+
+### Instructions:
+1.  **Test Framework**: Use the standard testing framework for the project (e.g., `pytest` for Python, `Jest` for JavaScript).
+2.  **Coverage Goal**: Aim for high test coverage of the upgraded code, focusing particularly on complex logic, state changes, and error handling paths.
+3.  **Unit Tests**: Write unit tests for individual functions and methods. Ensure they behave correctly given valid inputs, invalid inputs, and boundary conditions (edge cases).
+4.  **Integration Tests**: Write integration tests to ensure that the newly refactored components interact correctly with each other and with the immediate surrounding system.
+5.  **Mocking Strategy**: Use mocking libraries (like `unittest.mock` or `pytest-mock`) to isolate the code being tested. Mock external API calls, database interactions, and heavy I/O operations to keep tests fast and deterministic.
+6.  **Test Naming**: Use descriptive names for test functions (e.g., `test_calculate_risk_with_invalid_input_raises_value_error`) so the intent of the test is immediately clear.
+7.  **Execution**: Ensure the test suite is entirely self-contained and ready to run immediately.


### PR DESCRIPTION
This PR adds the Master Repository Upgrade Prompt template to the AOPL-v2.0 task library. The main prompt orchestrates a 7-phase upgrade cycle. I have logically separated the 7 phases into their own Markdown files within the `upgrade_modules` subdirectory for better modularity and organization.

---
*PR created automatically by Jules for task [7138889689041161958](https://jules.google.com/task/7138889689041161958) started by @adamvangrover*