### PR TITLE
⚡ Bolt: [React.memo optimization for SystemHealthMonitor logs]

### DIFF
--- a/webapp/src/components/system/SystemHealthMonitor.tsx
+++ b/webapp/src/components/system/SystemHealthMonitor.tsx
@@ -18,6 +18,29 @@ interface LogEntry {
   message: string;
 }
 
+
+const getLogLevelColor = (level: string) => {
+  switch (level) {
+    case 'INFO': return 'text-blue-400';
+    case 'WARN': return 'text-yellow-400';
+    case 'ERROR': return 'text-red-400';
+    default: return 'text-gray-300';
+  }
+};
+
+// ⚡ Bolt: Wrapped list item in React.memo to prevent O(N) re-renders
+// Since SystemHealthMonitor updates state every 3s via setInterval,
+// extracting this prevents re-rendering all existing 50 logs.
+const LogEntryRow = React.memo(({ log }: { log: LogEntry }) => (
+  <div className="mb-1 border-b border-gray-800 pb-1 last:border-0">
+    <span className="text-gray-500 mr-3">[{log.timestamp}]</span>
+    <span className={`font-bold mr-3 ${getLogLevelColor(log.level)}`}>{log.level}</span>
+    <span className="text-indigo-300 mr-3">[{log.source}]</span>
+    <span className="text-gray-300">{log.message}</span>
+  </div>
+));
+LogEntryRow.displayName = 'LogEntryRow';
+
 const SystemHealthMonitor: React.FC = () => {
   const [systemStatus, setSystemStatus] = useState<SystemStatus>({
     cpuUsage: 0,
@@ -65,14 +88,6 @@ const SystemHealthMonitor: React.FC = () => {
     }
   };
 
-  const getLogLevelColor = (level: string) => {
-    switch (level) {
-      case 'INFO': return 'text-blue-400';
-      case 'WARN': return 'text-yellow-400';
-      case 'ERROR': return 'text-red-400';
-      default: return 'text-gray-300';
-    }
-  };
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
@@ -138,12 +153,7 @@ const SystemHealthMonitor: React.FC = () => {
         
         <div className="flex-1 overflow-y-auto bg-gray-900 rounded p-4 font-mono text-sm custom-scrollbar">
           {logs.map((log) => (
-            <div key={log.id} className="mb-1 border-b border-gray-800 pb-1 last:border-0">
-              <span className="text-gray-500 mr-3">[{log.timestamp}]</span>
-              <span className={`font-bold mr-3 ${getLogLevelColor(log.level)}`}>{log.level}</span>
-              <span className="text-indigo-300 mr-3">[{log.source}]</span>
-              <span className="text-gray-300">{log.message}</span>
-            </div>
+            <LogEntryRow key={log.id} log={log} />
           ))}
           {logs.length === 0 && (
             <div className="text-gray-500 text-center mt-10">Waiting for system events...</div>


### PR DESCRIPTION
💡 **What:**
The inline list item rendering for system logs inside `SystemHealthMonitor.tsx` was extracted into a standalone `LogEntryRow` functional component and wrapped in `React.memo`. The `getLogLevelColor` helper function was also hoisted outside the component scope to avoid being redefined on every render.

🎯 **Why:**
The `SystemHealthMonitor` updates its internal state every 3 seconds using `setInterval` to push new system metrics and mock logs. Because the `logs` array was mapped inline, React was forced to re-render the entire list of up to 50 logs every time a single log was appended, resulting in an O(N) rendering cost. As the interval is fast and the list can be long, this degrades rendering performance over time.

📊 **Impact:**
Reduces re-renders by ~98% on each interval pulse. Instead of re-rendering all 50 items (cost O(N)), React now only renders the newly inserted log entry, reducing the re-render cost to O(1).

🔬 **Measurement:**
This can be verified using the React Profiler. Without the change, the "Commits" graph will show a heavy spike and deep component re-render tree for every list item during the 3s interval pulse. After the change, the profiler will demonstrate that the 49 previously existing `LogEntryRow` components skip rendering entirely, with only the newly unshifted element processing a commit.

---
*PR created automatically by Jules for task [16494851478657600539](https://jules.google.com/task/16494851478657600539) started by @adamvangrover*