### PR TITLE
🛡️ Sentinel: [MEDIUM] Prevent API from binding to all interfaces

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -200,3 +200,19 @@
 **Vulnerability:** The `news_bot.py` agent parsed untrusted RSS feed data using `xml.etree.ElementTree`, which is susceptible to XXE attacks. Additionally, it used `urllib.request.urlopen` which could theoretically be tricked into opening local files or unsupported schemes.
 **Learning:** Python's standard `xml.etree` is unsafe for untrusted XML. Standard library HTTP clients (`urllib`) require strict URL scheme validation, while modern clients (`requests`) are safer by default and provide easier API constraints. Furthermore, when adding security fixes that introduce third-party libraries (`defusedxml`), the dependency must be correctly added to the project's dependency manifest (`setup.py`) to prevent breaking the application, regardless of whether it's temporarily available in the environment via `requirements.txt`.
 **Prevention:** 1) Always use `defusedxml` when parsing any XML data not strictly controlled by the application. 2) Prefer the `requests` library for external HTTP calls over raw `urllib`. 3) Always update dependency lists (`setup.py` / `pyproject.toml`) when relying on a new third-party library to ensure the build remains resilient.
+## 2026-04-30 - Prevent binding to all interfaces (0.0.0.0)
+**Vulnerability:** Fast API application was binding to all interfaces (0.0.0.0), exposing it to external networks unnecessarily.
+**Learning:** Found in . Uvicorn bound to 0.0.0.0 by default. It must be explicitly bound to 127.0.0.1 for local deployments.
+**Prevention:** Configure local APIs to bind to localhost (127.0.0.1) explicitly unless external access is required. Use bandit usage: bandit [-h] [-r] [-a {file,vuln}] [-n CONTEXT_LINES] [-c CONFIG_FILE]
+              [-p PROFILE] [-t TESTS] [-s SKIPS]
+              [-l | --severity-level {all,low,medium,high}]
+              [-i | --confidence-level {all,low,medium,high}]
+              [-f {csv,custom,html,json,screen,txt,xml,yaml}]
+              [--msg-template MSG_TEMPLATE] [-o [OUTPUT_FILE]] [-v] [-d] [-q]
+              [--ignore-nosec] [-x EXCLUDED_PATHS] [-b BASELINE]
+              [--ini INI_PATH] [--exit-zero] [--version]
+              [targets ...] to scan for these risks.
+## 2026-04-30 - Prevent binding to all interfaces (0.0.0.0) in server
+**Vulnerability:** Fast API application was binding to all interfaces (0.0.0.0), exposing it to external networks unnecessarily.
+**Learning:** Found in server/sentinel_api.py. Uvicorn bound to 0.0.0.0 by default. It must be explicitly bound to 127.0.0.1 for local deployments.
+**Prevention:** Configure local APIs to bind to localhost (127.0.0.1) explicitly unless external access is required. Use bandit 'uv run bandit' to scan for these risks.

--- a/adam_project.egg-info/SOURCES.txt
+++ b/adam_project.egg-info/SOURCES.txt
@@ -904,8 +904,6 @@ services/webapp/config.py
 services/webapp/governance.py
 services/webapp/tests.py
 services/webapp/blueprints/quantum_blueprint.py
-services/webapp/client/node_modules/flatted/python/flatted.py
-services/webapp/client/node_modules/shell-quote/print.py
 services/webapp/client/public/favicon.ico
 services/webapp/client/public/index.html
 services/webapp/client/public/logo192.png

--- a/server/sentinel_api.py
+++ b/server/sentinel_api.py
@@ -39,4 +39,5 @@ def evaluate_credit(request: CreditRequest):
         raise HTTPException(status_code=400, detail=str(e))
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    # SECURITY: Bind to localhost (127.0.0.1) instead of 0.0.0.0 to prevent external access during local dev
+    uvicorn.run(app, host="127.0.0.1", port=8000)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Fast API application was binding to all interfaces (0.0.0.0), exposing it to external networks unnecessarily. This was identified in the Sentinel journal and fixed in `services/sentinel_api.py`, but `server/sentinel_api.py` still contained the vulnerability.
🎯 Impact: Unnecessary exposure of internal APIs to external networks, which could lead to unauthorized access or exploitation.
🔧 Fix: Explicitly bound the local API to localhost (127.0.0.1) in `server/sentinel_api.py`.
✅ Verification: Ran syntax checks and verified that the `server/sentinel_api.py` no longer uses `0.0.0.0` for `uvicorn.run`. Also ran `pytest` for server governance to ensure no functionality is broken. Added the learning to the Sentinel journal.

---
*PR created automatically by Jules for task [8626957484650946533](https://jules.google.com/task/8626957484650946533) started by @adamvangrover*