### PR TITLE
⚡ Bolt: Separate search index instantiation from execution in GlobalNav

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -132,3 +132,7 @@
 ## 2026-04-26 - React List Optimization
 **Learning:** Extracting inner mapped elements into separate functional components wrapped in `React.memo` (like `ThoughtRow`) is highly effective at preventing O(N) re-renders during frequent interval pulses in React UI components.
 **Action:** When auditing frontend performance, specifically look for inline `.map()` functions rendering complex JSX in frequently updating components, and extract/memoize them.
+
+## 2026-11-27 - [Separating Search Index Instantiation from Search Execution]
+**Learning:** In React components like `GlobalNav.tsx`, instantiating a search index (e.g., `new Fuse(...)`) within the same `useMemo` block or render path as the search execution causes a severe performance bottleneck. When the search index relies on static or slowly changing data (like a manifest) but is coupled with a rapidly changing dependency (like the `searchTerm` from every keystroke), the expensive O(N) index reconstruction happens on every key press, leading to noticeable input lag.
+**Action:** Always separate the search index instantiation and the search execution into two distinct `useMemo` hooks. The first hook should build the index and depend only on the data source, while the second hook should perform the search and depend on both the index and the search query. This ensures the index is built once when the data changes, and only the fast search operation runs on every keystroke.

--- a/webapp/src/components/GlobalNav.tsx
+++ b/webapp/src/components/GlobalNav.tsx
@@ -36,21 +36,25 @@ const GlobalNav: React.FC<GlobalNavProps> = ({ isOffline }) => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  const searchResults = useMemo(() => {
-    if (!searchTerm || !manifest) return [];
+  const fuseInstance = useMemo(() => {
+    if (!manifest) return null;
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const agents = (manifest.agents || []).map((a: any) => ({ ...a, type: 'agent' }));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const reports = (manifest.reports || []).map((r: any) => ({ ...r, type: 'report' }));
 
-    const fuse = new Fuse([...agents, ...reports], {
+    return new Fuse([...agents, ...reports], {
       keys: ['name', 'title', 'docstring', 'content'],
       threshold: 0.3
     });
+  }, [manifest]);
 
-    return fuse.search(searchTerm).slice(0, 5).map(r => r.item);
-  }, [searchTerm, manifest]);
+  const searchResults = useMemo(() => {
+    if (!searchTerm || !fuseInstance) return [];
+
+    return fuseInstance.search(searchTerm).slice(0, 5).map(r => r.item);
+  }, [searchTerm, fuseInstance]);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const handleSelection = (item: any) => {


### PR DESCRIPTION
💡 **What**: Separated the Fuse.js search index instantiation from the search execution into two distinct `useMemo` hooks within `GlobalNav.tsx`.
🎯 **Why**: Previously, the entire Fuse.js fuzzy search index was being rebuilt on every single keystroke because the index creation was inside the same `useMemo` block that depended on `searchTerm`. This caused severe performance bottlenecks.
📊 **Impact**: Prevents an expensive O(N) index reconstruction on every keystroke. Search typing should feel significantly faster and lag-free, especially for large lists of agents and reports.
🔬 **Measurement**: Launch the web app, open the global navigation search bar, and rapidly type a query. The UI will no longer hang on index creation.

*Included standard Bolt optimizations and updated the journal.*

---
*PR created automatically by Jules for task [9053822812764142078](https://jules.google.com/task/9053822812764142078) started by @adamvangrover*