### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing timeout in external API call

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -216,3 +216,7 @@
 **Vulnerability:** Fast API application was binding to all interfaces (0.0.0.0), exposing it to external networks unnecessarily.
 **Learning:** Found in server/sentinel_api.py. Uvicorn bound to 0.0.0.0 by default. It must be explicitly bound to 127.0.0.1 for local deployments.
 **Prevention:** Configure local APIs to bind to localhost (127.0.0.1) explicitly unless external access is required. Use bandit 'uv run bandit' to scan for these risks.
+## 2026-05-08 - Added timeout to requests.get in downloads/download_agents.py
+**Vulnerability:** A missing timeout in `requests.get` could lead to an infinite hang and a potential Denial of Service (CWE-400) if the remote server is unresponsive.
+**Learning:** Always specify a timeout for external network requests, even for simple download scripts, to ensure the application fails gracefully rather than hanging indefinitely.
+**Prevention:** Include a `timeout` parameter (e.g., `timeout=10`) in all `requests` calls to establish a maximum wait time.

--- a/downloads/download_agents.py
+++ b/downloads/download_agents.py
@@ -7,7 +7,8 @@ def download_agents():
     Downloads pre-configured agents from a remote repository.
     """
     agents_url = "https://raw.githubusercontent.com/adam-agi/adam/main/config/agents.yaml"
-    response = requests.get(agents_url)
+    # Added timeout to prevent potential denial of service if the server hangs
+    response = requests.get(agents_url, timeout=10)
     agents_config = response.text
 
     with open("config/downloaded_agents.yaml", "w") as f:


### PR DESCRIPTION
Added a `timeout=10` argument to the `requests.get` call in `downloads/download_agents.py` to prevent potential denial of service (CWE-400) caused by indefinite hanging. This addresses a MEDIUM severity security issue identified by Bandit. Also appended to the Sentinel journal.

---
*PR created automatically by Jules for task [6033457150484800478](https://jules.google.com/task/6033457150484800478) started by @adamvangrover*