### PR TITLE
⚡ Bolt: Replace setInterval with recursive setTimeout in SimulationTools

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -152,3 +152,6 @@
 ## 2026-11-28 - [React Polling Optimization]
 **Learning:** In periodic network polls (like in `AuditLogViewer`), using `setInterval` can cause request pile-ups during slow API responses, and blindly calling `setState(data)` causes React to re-render the whole component list even if the data is identical. `React.memo` alone won't prevent list re-renders when data references change (e.g., from `res.json()`).
 **Action:** Replace `setInterval` with a recursive `setTimeout`, check for `isMounted`, and use deep equality checks (e.g., `JSON.stringify(prev) !== JSON.stringify(data)`) inside the state setter to skip setting state and avoid unnecessary full re-renders when data is unchanged.
+## 2026-05-11 - [Polling Loop Robustness]
+**Learning:** When replacing `setInterval` with recursive `setTimeout` to prevent request pile-ups during network polls, using `await` inside the polling function without a `try/catch` block creates a fatal fragility. If the awaited fetch throws an error (e.g., network failure), the error will bubble up, permanently halt the function's execution, and prevent the next `setTimeout` from ever scheduling, thus killing the polling loop entirely.
+**Action:** Always wrap `await` API calls inside recursive polling functions with a `try/catch` block to ensure the timeout correctly schedules the next poll regardless of temporary failures.

--- a/services/webapp/client/src/pages/SimulationTools.js
+++ b/services/webapp/client/src/pages/SimulationTools.js
@@ -77,13 +77,33 @@ function Simulations() {
 
     // Polling for status updates
     useEffect(() => {
-        const interval = setInterval(() => {
+        let timeoutId;
+        let isMounted = true;
+
+        const pollHistory = async () => {
+            if (!isMounted) return;
             const running = history.some(run => run.status === 'PENDING' || run.status === 'STARTED');
             if (running) {
-                fetchHistory();
+                try {
+                    await fetchHistory();
+                } catch (e) {
+                    console.error("Failed to fetch simulation history:", e);
+                }
             }
-        }, 5000);
-        return () => clearInterval(interval);
+            // Bolt Optimization ⚡: Replace setInterval with recursive setTimeout to prevent
+            // request pile-ups during slow API responses
+            if (isMounted) {
+                timeoutId = setTimeout(pollHistory, 5000);
+            }
+        };
+
+        // Delay the first execution by 5000ms just like the original setInterval
+        timeoutId = setTimeout(pollHistory, 5000);
+
+        return () => {
+            isMounted = false;
+            if (timeoutId) clearTimeout(timeoutId);
+        };
     }, [history, fetchHistory]);
 
 


### PR DESCRIPTION
💡 **What:** Replaced the `setInterval` logic inside the history polling `useEffect` in `SimulationTools.js` with a recursive `setTimeout` pattern guarded by an `isMounted` flag and a `try/catch` block.

🎯 **Why:** Using `setInterval` to periodically poll an endpoint like `/api/simulations/history` causes request pile-ups if the API is slow and takes longer to respond than the 5-second interval. This could result in multiple overlapping requests, slowing the browser main thread and overwhelming the backend.

📊 **Impact:** Increases client stability, prevents network congestion, and prevents potential memory leaks by checking `isMounted`. By ensuring the fetch is surrounded by a `try/catch` block, we avoid the recursive poll failing outright if a transient network failure occurs.

🔬 **Measurement:** Verify by navigating to the Simulation Tools page. The history should still update every 5 seconds without errors, and no duplicate pending requests should build up in the network tab if network throttling is applied.

---
*PR created automatically by Jules for task [16270254782314170566](https://jules.google.com/task/16270254782314170566) started by @adamvangrover*