### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection and Path Traversal in GitHubAlphaAgent

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -220,3 +220,8 @@
 **Vulnerability:** A missing timeout in `requests.get` could lead to an infinite hang and a potential Denial of Service (CWE-400) if the remote server is unresponsive.
 **Learning:** Always specify a timeout for external network requests, even for simple download scripts, to ensure the application fails gracefully rather than hanging indefinitely.
 **Prevention:** Include a `timeout` parameter (e.g., `timeout=10`) in all `requests` calls to establish a maximum wait time.
+
+## 2026-05-18 - Missing Scheme Validation in GitHubAlphaAgent
+**Vulnerability:** The `GitHubAlphaAgent` executed `subprocess.run(["git", "clone", ...])` with untrusted URLs without validating the scheme, allowing potential RCE via Git's `ext::` protocol or local file disclosure via the `file://` protocol.
+**Learning:** `git clone` natively supports dangerous protocols like `ext::` which allows command execution. Merely preventing options injection with `--` is not enough to secure Git commands against untrusted inputs.
+**Prevention:** Always validate URL schemes (e.g., restricting to `http://` and `https://`) before passing them to external command line utilities like `git` or `curl`.

--- a/core/agents/specialized/github_alpha_agent.py
+++ b/core/agents/specialized/github_alpha_agent.py
@@ -1,10 +1,11 @@
-from typing import Dict, Any, List, Optional
-import os
-import subprocess
-import shutil
-import tempfile
 import logging
+import os
+import shutil
+import subprocess
+import tempfile
 from datetime import datetime, timedelta
+from typing import Any, Dict, List
+
 from pydantic import BaseModel, Field
 
 from core.agents.agent_base import AgentBase
@@ -32,6 +33,10 @@ class GitHubAlphaAgent(AgentBase):
         super().__init__(config or {})
         self.temp_dir = tempfile.gettempdir()
 
+    def _validate_url(self, repo_url: str):
+        if not repo_url.startswith(("http://", "https://")):
+            raise ValueError("Invalid URL scheme. Only http/https are allowed.")
+
     async def execute(self, query: str, context: Dict[str, Any] = None) -> Dict[str, Any]:
         """
         Analyzes a GitHub repository for activity metrics.
@@ -46,15 +51,44 @@ class GitHubAlphaAgent(AgentBase):
         context = context or {}
         repo_url = query.strip()
         days = context.get("days", 30)
-        branch = context.get("branch", None) # Let git decide default if None
+        branch = context.get("branch", None)  # Let git decide default if None
+
+        try:
+            self._validate_url(repo_url)
+        except ValueError as e:
+            return AgentOutput(
+                answer=f"Failed to analyze repository: {str(e)}",
+                sources=[repo_url],
+                confidence=0.0,
+                metadata={"error": str(e)}
+            ).model_dump()
 
         logger.info(f"GitHubAlphaAgent analyzing: {repo_url} for past {days} days.")
 
         # Create a unique temp directory for this clone
-        repo_name = repo_url.split("/")[-1].replace(".git", "")
+        repo_name = repo_url.rstrip('/').split("/")[-1].replace(".git", "")
+
+        if not repo_name or ".." in repo_name or "/" in repo_name or "\\" in repo_name:
+            return AgentOutput(
+                answer="Failed to analyze repository: Invalid repository name extracted from URL.",
+                sources=[repo_url],
+                confidence=0.0,
+                metadata={"error": "Invalid repository name extracted from URL."}
+            ).model_dump()
+
         # Use a safe timestamp
         ts = datetime.now().strftime('%Y%m%d%H%M%S')
         clone_path = os.path.join(self.temp_dir, f"alpha_agent_{repo_name}_{ts}")
+
+        abs_clone_path = os.path.abspath(clone_path)
+        abs_temp_dir = os.path.abspath(self.temp_dir)
+        if os.path.commonpath([abs_temp_dir, abs_clone_path]) != abs_temp_dir or abs_clone_path == abs_temp_dir:
+            return AgentOutput(
+                answer="Failed to analyze repository: Path traversal detected.",
+                sources=[repo_url],
+                confidence=0.0,
+                metadata={"error": "Security Violation: Path traversal detected."}
+            ).model_dump()
 
         try:
             # 1. Clone the repo


### PR DESCRIPTION
Fixes a critical security issue in `GitHubAlphaAgent` where an untrusted URL could be used to execute arbitrary commands by leveraging `ext::` protocol when passed to `git clone`. Implemented validation restricting URLs strictly to `http://` and `https://` and checking for path traversal characters. Updated testing and Sentinel log accordingly.

---
*PR created automatically by Jules for task [17376381702398260271](https://jules.google.com/task/17376381702398260271) started by @adamvangrover*