### PR TITLE
⚡ Bolt: Remove inline style injections to prevent layout thrashing

### DIFF
--- a/services/webapp/client/src/components/promptAlpha/NewsWire.tsx
+++ b/services/webapp/client/src/components/promptAlpha/NewsWire.tsx
@@ -94,15 +94,6 @@ export const NewsWire: React.FC = () => {
             ))}
         </div>
 
-        <style>{`
-            .animate-spin-slow { animation: spin 4s linear infinite; }
-            @keyframes spin { 100% { transform: rotate(360deg); } }
-            @keyframes flash {
-                0% { background-color: rgba(34, 211, 238, 0.2); }
-                100% { background-color: transparent; }
-            }
-            .animate-flash { animation: flash 1s ease-out; }
-        `}</style>
     </div>
   );
 };

--- a/services/webapp/client/src/components/promptAlpha/TickerTape.tsx
+++ b/services/webapp/client/src/components/promptAlpha/TickerTape.tsx
@@ -29,15 +29,6 @@ export const TickerTape: React.FC = () => {
         ))}
         {/* Duplicate for seamless loop if needed, simplified here */}
       </div>
-      <style>{`
-        @keyframes marquee {
-          0% { transform: translateX(0); }
-          100% { transform: translateX(-100%); }
-        }
-        .animate-marquee {
-          animation: marquee 30s linear infinite;
-        }
-      `}</style>
     </div>
   );
 };

--- a/services/webapp/client/src/index.css
+++ b/services/webapp/client/src/index.css
@@ -50,3 +50,61 @@
   0% { transform: rotate(0deg); }
   100% { transform: rotate(360deg); }
 }
+
+/* Extracted Animations to prevent layout thrashing */
+
+.animate-spin-slow { animation: spin 4s linear infinite; }
+@keyframes flash {
+  0% { background-color: rgba(34, 211, 238, 0.2); }
+  100% { background-color: transparent; }
+}
+.animate-flash { animation: flash 1s ease-out; }
+
+@keyframes marquee {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-100%); }
+}
+.animate-marquee {
+  animation: marquee 30s linear infinite;
+}
+
+@keyframes scan-synthesizer {
+  0% { transform: translateY(-100%); opacity: 0; }
+  50% { opacity: 1; }
+  100% { transform: translateY(1000%); opacity: 0; }
+}
+
+@keyframes scan-evolution {
+  0% { top: 0%; }
+  100% { top: 100%; }
+}
+.scan-line {
+  width: 100%;
+  height: 2px;
+  background: rgba(168, 85, 247, 0.3);
+  opacity: 0.5;
+  animation: scan-evolution 4s linear infinite;
+  position: fixed;
+  top: 0;
+  pointer-events: none;
+  z-index: 50;
+}
+.glass-panel {
+  background: rgba(13, 20, 31, 0.7);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(59, 130, 246, 0.15);
+  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
+}
+.glass-panel-active {
+  border: 1px solid rgba(168, 85, 247, 0.4);
+  box-shadow: 0 0 20px rgba(168, 85, 247, 0.15);
+}
+.text-glow {
+  text-shadow: 0 0 10px rgba(255, 255, 255, 0.3);
+}
+
+/* Scrollbar */
+::-webkit-scrollbar { width: 8px; }
+::-webkit-scrollbar-track { background: #0f172a; }
+::-webkit-scrollbar-thumb { background: #334155; border-radius: 4px; }
+::-webkit-scrollbar-thumb:hover { background: #475569; }

--- a/services/webapp/client/src/pages/EvolutionHub.tsx
+++ b/services/webapp/client/src/pages/EvolutionHub.tsx
@@ -234,42 +234,6 @@ const EvolutionHub = () => {
 
     return (
         <div className="min-h-screen bg-[#050b14] text-slate-200 font-mono relative overflow-hidden flex flex-col">
-            {/* Custom CSS */}
-            <style>{`
-                @keyframes scan {
-                    0% { top: 0%; }
-                    100% { top: 100%; }
-                }
-                .scan-line {
-                    width: 100%;
-                    height: 2px;
-                    background: rgba(168, 85, 247, 0.3);
-                    opacity: 0.5;
-                    animation: scan 4s linear infinite;
-                    position: fixed;
-                    top: 0;
-                    pointer-events: none;
-                    z-index: 50;
-                }
-                .glass-panel {
-                    background: rgba(13, 20, 31, 0.7);
-                    backdrop-filter: blur(12px);
-                    border: 1px solid rgba(59, 130, 246, 0.15);
-                    box-shadow: 0 4px 30px rgba(0, 0, 0, 0.1);
-                }
-                .glass-panel-active {
-                    border: 1px solid rgba(168, 85, 247, 0.4);
-                    box-shadow: 0 0 20px rgba(168, 85, 247, 0.15);
-                }
-                .text-glow {
-                    text-shadow: 0 0 10px rgba(255, 255, 255, 0.3);
-                }
-                /* Scrollbar */
-                ::-webkit-scrollbar { width: 8px; }
-                ::-webkit-scrollbar-track { background: #0f172a; }
-                ::-webkit-scrollbar-thumb { background: #334155; border-radius: 4px; }
-                ::-webkit-scrollbar-thumb:hover { background: #475569; }
-            `}</style>
 
             <div className="scan-line"></div>
 

--- a/services/webapp/client/src/pages/Synthesizer.tsx
+++ b/services/webapp/client/src/pages/Synthesizer.tsx
@@ -327,7 +327,7 @@ const Synthesizer: React.FC = () => {
                         {Object.entries(conviction).map(([agent, val]) => (
                             <div key={agent} style={{ textAlign: 'center', padding: '10px', background: `rgba(0, 255, 0, ${val * 0.3})`, border: `1px solid rgba(0,255,0,${val})`, borderRadius: '4px', position: 'relative', overflow: 'hidden' }}>
                                 {/* Animated scanning bar */}
-                                <div style={{ position: 'absolute', top: 0, left: 0, right: 0, height: '2px', background: 'rgba(255,255,255,0.5)', animation: 'scan 3s linear infinite' }}></div>
+                                <div style={{ position: 'absolute', top: 0, left: 0, right: 0, height: '2px', background: 'rgba(255,255,255,0.5)', animation: 'scan-synthesizer 3s linear infinite' }}></div>
                                 <div style={{ fontSize: '0.7rem', fontWeight: 'bold' }}>{agent}</div>
                                 <div style={{ fontSize: '1.2rem', color: '#fff' }}>{(val * 100).toFixed(0)}%</div>
                                 {val > 0.8 && <div style={{ fontSize: '0.55rem', color: '#000', background: '#0f0', padding: '2px', marginTop: '5px', borderRadius: '2px' }}>HIGH CONVICTION</div>}
@@ -335,14 +335,6 @@ const Synthesizer: React.FC = () => {
                             </div>
                         ))}
                     </div>
-                    {/* Add keyframes globally for scanning bar */}
-                    <style>{`
-                        @keyframes scan {
-                            0% { transform: translateY(-100%); opacity: 0; }
-                            50% { opacity: 1; }
-                            100% { transform: translateY(1000%); opacity: 0; }
-                        }
-                    `}</style>
                 </div>
 
                 {/* 7. Forecast Chart (SVG) */}


### PR DESCRIPTION
### 💡 What:
Moved `@keyframes` and static CSS classes (like `.scan-line`, `.animate-flash`) out of functional React components into the global `index.css`.

### 🎯 Why:
React components that inject `<style>` tags on every render cause unnecessary style recalculations and layout thrashing, especially in components with frequent state updates (like polling intervals or streaming data). This forces the browser to re-parse the CSSOM unnecessarily.

### 📊 Impact:
Eliminates layout thrashing caused by style injection on re-renders for `NewsWire`, `TickerTape`, `Synthesizer`, and `EvolutionHub`. Reduces CPU overhead during component updates.

### 🔬 Measurement:
Run the app and observe the CSS DOM structure. The `<style>` tags no longer repeatedly mount/unmount inside the component trees during state updates.

*Note: Resolved a keyframe naming collision by renaming the `scan` animations to `scan-synthesizer` and `scan-evolution`.*

---
*PR created automatically by Jules for task [5504699732228063706](https://jules.google.com/task/5504699732228063706) started by @adamvangrover*