### PR TITLE
Scaffold Governance Gatekeeper (PDIL)

### DIFF
--- a/core/pdil/integration_layer.py
+++ b/core/pdil/integration_layer.py
@@ -1,0 +1,56 @@
+import json
+import jsonschema
+from pydantic import BaseModel, Field
+from typing import Dict, Any, Optional
+
+class ProvenanceHeader(BaseModel):
+    git_commit_hash: str = Field(..., description="Git commit hash of the environment")
+    timestamp: str = Field(..., description="ISO 8601 timestamp of execution")
+    content_hash: str = Field(..., description="SHA-256 hash of the generated content")
+    jsonLogic_version: str = Field(..., description="Version of the jsonLogic schema used")
+    confidence_score: float = Field(..., description="Agent conviction score (0.0 to 1.0)")
+    derivation_path: str = Field(..., description="Path indicating how the conclusion was reached")
+
+class GovernanceError(Exception):
+    """Raised when an inference fails governance validation (e.g. invalid schema, missing provenance, poisoned data)."""
+    pass
+
+class GovernanceGatekeeper:
+    def __init__(self, schema: Dict[str, Any]):
+        """
+        Initializes the gatekeeper with a specific JSON schema constraint.
+        """
+        self.schema = schema
+
+    def validate_inference(self, inference_output: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Validates LLM probabilistic inferences natively using jsonschema.
+        Ensures the presence of a valid ProvenanceHeader.
+        Raises GovernanceError if validation fails or data is poisoned.
+        """
+
+        if "provenance_trace" not in inference_output:
+            raise GovernanceError("Missing 'provenance_trace' containing the ProvenanceHeader.")
+
+        try:
+            # Pydantic validation for the header
+            header = ProvenanceHeader(**inference_output["provenance_trace"])
+        except Exception as e:
+            raise GovernanceError(f"Invalid ProvenanceHeader: {e}")
+
+        # Optional: Poison check based on confidence score boundary issues
+        if header.confidence_score < 0.0 or header.confidence_score > 1.0:
+             raise GovernanceError("Poisoned data detected: confidence score out of bounds.")
+
+        # Extract the actual data payload to validate against the schema
+        payload = inference_output.get("data", {})
+
+        if not payload:
+            raise GovernanceError("Missing 'data' payload in inference output.")
+
+        try:
+            jsonschema.validate(instance=payload, schema=self.schema)
+        except jsonschema.exceptions.ValidationError as e:
+            raise GovernanceError(f"Schema validation failed: {e.message}")
+
+        return inference_output

--- a/tests/evals/test_fiduciary_fitness.py
+++ b/tests/evals/test_fiduciary_fitness.py
@@ -1,0 +1,98 @@
+import pytest
+from hypothesis import given, settings, HealthCheck, strategies as st
+from core.pdil.integration_layer import GovernanceGatekeeper, GovernanceError
+
+VALID_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "analysis": {"type": "string"},
+        "score": {"type": "number"}
+    },
+    "required": ["analysis", "score"]
+}
+
+# Generators for ProvenanceHeader fields
+git_hashes = st.text(alphabet="0123456789abcdef", min_size=40, max_size=40)
+timestamps = st.text(min_size=1) # simplified ISO 8601 mock
+content_hashes = st.text(alphabet="0123456789abcdef", min_size=64, max_size=64)
+versions = st.text(min_size=1)
+paths = st.text(min_size=1)
+
+@given(
+    st.dictionaries(
+        keys=st.sampled_from(["analysis", "score"]),
+        values=st.one_of(st.text(), st.integers()),
+    ),
+    st.floats(min_value=-10.0, max_value=10.0)
+)
+@settings(suppress_health_check=[HealthCheck.too_slow])
+def test_governance_gatekeeper_fuzz(payload, confidence):
+    gatekeeper = GovernanceGatekeeper(schema=VALID_SCHEMA)
+
+    inference_output = {
+        "provenance_trace": {
+            "git_commit_hash": "a"*40,
+            "timestamp": "2023-10-27T10:00:00Z",
+            "content_hash": "b"*64,
+            "jsonLogic_version": "1.0",
+            "confidence_score": confidence,
+            "derivation_path": "test_path"
+        },
+        "data": payload
+    }
+
+    # It must raise GovernanceError if the data is poisoned (confidence score out of bounds)
+    # or if the payload fails schema validation
+    is_valid_payload = isinstance(payload.get("analysis"), str) and isinstance(payload.get("score"), (int, float)) and "analysis" in payload and "score" in payload
+    is_valid_confidence = 0.0 <= confidence <= 1.0
+
+    if not is_valid_payload or not is_valid_confidence:
+        with pytest.raises(GovernanceError):
+            gatekeeper.validate_inference(inference_output)
+    else:
+        # Should pass
+        result = gatekeeper.validate_inference(inference_output)
+        assert result == inference_output
+
+def test_missing_provenance_trace():
+    gatekeeper = GovernanceGatekeeper(schema=VALID_SCHEMA)
+    inference_output = {
+        "data": {"analysis": "Looks good", "score": 0.8}
+    }
+
+    with pytest.raises(GovernanceError, match="Missing 'provenance_trace'"):
+        gatekeeper.validate_inference(inference_output)
+
+def test_invalid_provenance_trace():
+    gatekeeper = GovernanceGatekeeper(schema=VALID_SCHEMA)
+    inference_output = {
+        "provenance_trace": {
+            "git_commit_hash": "a"*40,
+            # missing timestamp
+            "content_hash": "b"*64,
+            "jsonLogic_version": "1.0",
+            "confidence_score": 0.9,
+            "derivation_path": "test_path"
+        },
+        "data": {"analysis": "Looks good", "score": 0.8}
+    }
+
+    with pytest.raises(GovernanceError, match="Invalid ProvenanceHeader"):
+        gatekeeper.validate_inference(inference_output)
+
+def test_valid_inference():
+    gatekeeper = GovernanceGatekeeper(schema=VALID_SCHEMA)
+    inference_output = {
+        "provenance_trace": {
+            "git_commit_hash": "a"*40,
+            "timestamp": "2023-10-27T10:00:00Z",
+            "content_hash": "b"*64,
+            "jsonLogic_version": "1.0",
+            "confidence_score": 0.9,
+            "derivation_path": "test_path"
+        },
+        "data": {"analysis": "Looks good", "score": 0.8}
+    }
+
+    result = gatekeeper.validate_inference(inference_output)
+    assert result == inference_output


### PR DESCRIPTION
Implements the `GovernanceGatekeeper` module within `core/pdil/integration_layer.py` to enforce deterministic validation on probabilistic agent outputs. This introduces the `ProvenanceHeader` Pydantic model to mandate tracing (git hash, timestamp, confidence scores) and dynamically validates outputs using `jsonschema`. Also implements property-based "Fiduciary Fitness" fuzz testing using `hypothesis` to verify poison data rejection and schema bounding under `tests/evals/test_fiduciary_fitness.py`.

---
*PR created automatically by Jules for task [5616214621033529430](https://jules.google.com/task/5616214621033529430) started by @adamvangrover*