### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix insecure Hugging Face Hub download without revision pinning

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -230,3 +230,8 @@
 **Vulnerability:** `WorkspaceManager._run_hook` executed `subprocess.run(['bash', '-lc', script])`. If an attacker supplies a script string starting with `-` (like `-i`), `bash` interprets it as an option instead of a script payload, leading to an unexpected execution behavior or potential bypasses.
 **Learning:** Even when passing a script directly to an interpreter like `bash -c`, untrusted scripts that start with a hyphen can cause argument injection.
 **Prevention:** Always use the end-of-options separator `--` before the untrusted payload when evaluating it via interpreters like bash (e.g., `['bash', '-lc', '--', script]`).
+
+## 2026-05-24 - Unsafe Hugging Face Hub download without revision pinning
+**Vulnerability:** Hugging Face model downloads via `from_pretrained()` without a `revision` parameter are vulnerable to supply chain attacks, as the default branch can be updated with malicious weights.
+**Learning:** Bandit rule B615 explicitly requires pinning the `revision` parameter to a specific cryptographic commit hash (not a branch tag like "main") for secure model fetching.
+**Prevention:** Always pin Hugging Face dependencies to a verifiable commit hash (e.g., `revision="27d67f1b5f57dc0953326b2601d68371d40ea8da"`) when calling `from_pretrained()`.

--- a/core/ppo_trainer.py
+++ b/core/ppo_trainer.py
@@ -82,8 +82,10 @@ def your_data_collator(data):
 
 
 # 1. Configuration for the Harness
+MODEL_NAME = "mistralai/Mistral-7B-v0.1"
+MODEL_REVISION = "27d67f1b5f57dc0953326b2601d68371d40ea8da"
 config = PPOConfig(
-    model_name="mistralai/Mistral-7B-v0.1",
+    model_name=MODEL_NAME,
     learning_rate=1.41e-5,
     batch_size=16,
     mini_batch_size=4,
@@ -103,6 +105,7 @@ lora_config = LoraConfig(
 # 3. Load the Actor and Critic (Value Head) together
 model = AutoModelForCausalLMWithValueHead.from_pretrained(
     config.model_name,
+    revision=MODEL_REVISION,
     peft_config=lora_config,
     device_map="auto",
     load_in_8bit=True,  # Requires bitsandbytes
@@ -111,7 +114,7 @@ model = AutoModelForCausalLMWithValueHead.from_pretrained(
 # The Reference model is automatically handled by trl
 # (it disables the LoRA adapters to get reference probabilities)
 
-tokenizer = AutoTokenizer.from_pretrained(config.model_name)
+tokenizer = AutoTokenizer.from_pretrained(config.model_name, revision=MODEL_REVISION)
 tokenizer.pad_token = tokenizer.eos_token
 
 # 4. Initialize the PPO Trainer


### PR DESCRIPTION
This PR fixes a security vulnerability (`B615:huggingface_unsafe_download`) reported by Bandit in `core/ppo_trainer.py`. Hugging Face models should be pinned to a specific cryptographic commit hash rather than relying on a default branch which could be compromised in a supply chain attack. Both `AutoModelForCausalLMWithValueHead.from_pretrained` and `AutoTokenizer.from_pretrained` are now pinned to the current commit hash for `mistralai/Mistral-7B-v0.1` (`27d67f1b5f57dc0953326b2601d68371d40ea8da`). The security fix has been logged in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15072499193468199439](https://jules.google.com/task/15072499193468199439) started by @adamvangrover*