### PR TITLE
⚡ Bolt: Optimize JSON schema validation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -172,3 +172,7 @@
 ## 2023-10-25 - [Optimize JSON Schema Validation]
 **Learning:** `jsonschema.validate()` implicitly evaluates the validity of the schema and re-compiles the validator upon every single function call. This creates significant overhead when doing frequent validations against a static schema (like inside the GovernanceGatekeeper processing loops).
 **Action:** Always extract the validation to an explicitly instantiated validator class (e.g., using `jsonschema.validators.validator_for(schema)` and pre-compiling it via `ValidatorClass(schema)`) to reuse it across multiple validations for a dramatic speedup (often 50-100x).
+
+## 2024-05-29 - [Optimize JSON Schema Validation Compilation]
+**Learning:** `jsonschema.validate(instance, schema)` forces the library to determine the correct validator class and recompile the schema definitions on every single invocation, creating a massive bottleneck on hot paths like parsing LLM outputs or validating incoming entities.
+**Action:** Always pre-compile the schema during component initialization (e.g., `ValidatorClass = jsonschema.validators.validator_for(schema); self.validator = ValidatorClass(schema)`) and reuse the instance (`self.validator.validate(instance)`) for validation to skip the compilation overhead.

--- a/core/engine/odyssey_knowledge_graph.py
+++ b/core/engine/odyssey_knowledge_graph.py
@@ -22,6 +22,7 @@ class OdysseyKnowledgeGraph(UnifiedKnowledgeGraph):
     def __init__(self):
         super().__init__()
         self.odyssey_schema = None
+        self.odyssey_validator = None
         self._load_odyssey_schema()
 
     def _load_odyssey_schema(self):
@@ -30,6 +31,10 @@ class OdysseyKnowledgeGraph(UnifiedKnowledgeGraph):
             try:
                 with open(schema_path, "r") as f:
                     self.odyssey_schema = json.load(f)
+                    # Bolt Optimization: Pre-compile jsonschema validator to avoid recompilation overhead on every validation request.
+                    if jsonschema:
+                        ValidatorClass = jsonschema.validators.validator_for(self.odyssey_schema)
+                        self.odyssey_validator = ValidatorClass(self.odyssey_schema)
                 logger.info("Loaded Odyssey FIBO Schema.")
             except Exception as e:
                 logger.error(f"Failed to load Odyssey schema: {e}")
@@ -42,7 +47,7 @@ class OdysseyKnowledgeGraph(UnifiedKnowledgeGraph):
         """
         if self.odyssey_schema and jsonschema:
             try:
-                jsonschema.validate(instance=entity_data, schema=self.odyssey_schema)
+                self.odyssey_validator.validate(instance=entity_data)
             except jsonschema.ValidationError as e:
                 logger.error(f"Schema Validation Failed: {e}")
                 raise ValueError(f"Entity does not conform to Odyssey FIBO Schema: {e}")

--- a/core/schema_middleware.py
+++ b/core/schema_middleware.py
@@ -9,6 +9,11 @@ class SchemaMiddleware:
     """
     def __init__(self, schema: dict = None):
         self.schema = schema
+        self.validator = None
+        if schema:
+                # Bolt Optimization: Pre-compile jsonschema validator to avoid recompilation overhead on every validation request.
+            ValidatorClass = jsonschema.validators.validator_for(schema)
+            self.validator = ValidatorClass(schema)
 
     def validate_and_parse(self, llm_output: str):
         """
@@ -20,7 +25,7 @@ class SchemaMiddleware:
             parsed = json.loads(llm_output)
 
             if self.schema:
-                jsonschema.validate(instance=parsed, schema=self.schema)
+                self.validator.validate(instance=parsed)
 
             return True, parsed
         except json.JSONDecodeError as e:


### PR DESCRIPTION
💡 What: Updated `SchemaMiddleware` and `OdysseyKnowledgeGraph` to pre-compile their `jsonschema` validators upon initialization rather than calling `jsonschema.validate()` on every request.

🎯 Why: `jsonschema.validate()` inherently determines the validator class and recompiles the schema structure on every invocation. By moving this compilation step to the component's `__init__` or setup phase, we avoid massive redundant CPU overhead on hot paths (such as the validation of stream-parsed LLM outputs and individual entity ingestions).

📊 Impact: Significantly improves throughput and reduces latency for any operations invoking JSON schema validation against static schemas.

🔬 Measurement: Verified functionality by executing the test suite (`python -m pytest tests/test_odyssey_flow.py` and `test_v23_5_schema.py`). Ensure tests still correctly catch validation errors.

---
*PR created automatically by Jules for task [13239464987359096051](https://jules.google.com/task/13239464987359096051) started by @adamvangrover*