### PR TITLE
Fix CI pipeline by explicitly pinning jsonschema in requirements.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -157,3 +157,4 @@ duckdb
 pandas
 pathspec
 tiktoken==0.12.0
+jsonschema==4.26.0


### PR DESCRIPTION
Fix CI pipeline by explicitly pinning jsonschema in requirements.txt

The Python unit and security tests were failing due to `jsonschema` not being present in `requirements/base.txt`. The codebase relies on `jsonschema` for optimizing schema validations natively in `src/governance/gatekeeper.py`, `core/schema_middleware.py`, and `core/engine/odyssey_knowledge_graph.py` to bypass overhead (the "Bolt Optimization"). The fix explicitly adds `jsonschema==4.26.0` to the base requirements.

---
*PR created automatically by Jules for task [7329549748219143983](https://jules.google.com/task/7329549748219143983) started by @adamvangrover*