### PR TITLE
Fix showcase static HTML 404 links

### DIFF
--- a/showcase/comprehensive_index.html
+++ b/showcase/comprehensive_index.html
@@ -717,1137 +717,1137 @@
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/1987-10-23_Market_Mayhem.html">1987-10-23_Market_Mayhem.html</a>
+                    <a href="1987-10-23_Market_Mayhem.html">1987-10-23_Market_Mayhem.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/2008-09-19_Market_Mayhem.html">2008-09-19_Market_Mayhem.html</a>
+                    <a href="2008-09-19_Market_Mayhem.html">2008-09-19_Market_Mayhem.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/2020-03-20_Market_Mayhem.html">2020-03-20_Market_Mayhem.html</a>
+                    <a href="2020-03-20_Market_Mayhem.html">2020-03-20_Market_Mayhem.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_01_08.html">Daily_Briefing_2025_01_08.html</a>
+                    <a href="Daily_Briefing_2025_01_08.html">Daily_Briefing_2025_01_08.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_01_13.html">Daily_Briefing_2025_01_13.html</a>
+                    <a href="Daily_Briefing_2025_01_13.html">Daily_Briefing_2025_01_13.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_01_14.html">Daily_Briefing_2025_01_14.html</a>
+                    <a href="Daily_Briefing_2025_01_14.html">Daily_Briefing_2025_01_14.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_01_21.html">Daily_Briefing_2025_01_21.html</a>
+                    <a href="Daily_Briefing_2025_01_21.html">Daily_Briefing_2025_01_21.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_01_27.html">Daily_Briefing_2025_01_27.html</a>
+                    <a href="Daily_Briefing_2025_01_27.html">Daily_Briefing_2025_01_27.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_01_28.html">Daily_Briefing_2025_01_28.html</a>
+                    <a href="Daily_Briefing_2025_01_28.html">Daily_Briefing_2025_01_28.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_01_30.html">Daily_Briefing_2025_01_30.html</a>
+                    <a href="Daily_Briefing_2025_01_30.html">Daily_Briefing_2025_01_30.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_02_06.html">Daily_Briefing_2025_02_06.html</a>
+                    <a href="Daily_Briefing_2025_02_06.html">Daily_Briefing_2025_02_06.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_02_13.html">Daily_Briefing_2025_02_13.html</a>
+                    <a href="Daily_Briefing_2025_02_13.html">Daily_Briefing_2025_02_13.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_02_14.html">Daily_Briefing_2025_02_14.html</a>
+                    <a href="Daily_Briefing_2025_02_14.html">Daily_Briefing_2025_02_14.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_02_17.html">Daily_Briefing_2025_02_17.html</a>
+                    <a href="Daily_Briefing_2025_02_17.html">Daily_Briefing_2025_02_17.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_02_27.html">Daily_Briefing_2025_02_27.html</a>
+                    <a href="Daily_Briefing_2025_02_27.html">Daily_Briefing_2025_02_27.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_02_28.html">Daily_Briefing_2025_02_28.html</a>
+                    <a href="Daily_Briefing_2025_02_28.html">Daily_Briefing_2025_02_28.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_03_03.html">Daily_Briefing_2025_03_03.html</a>
+                    <a href="Daily_Briefing_2025_03_03.html">Daily_Briefing_2025_03_03.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_03_11.html">Daily_Briefing_2025_03_11.html</a>
+                    <a href="Daily_Briefing_2025_03_11.html">Daily_Briefing_2025_03_11.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_03_12.html">Daily_Briefing_2025_03_12.html</a>
+                    <a href="Daily_Briefing_2025_03_12.html">Daily_Briefing_2025_03_12.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_03_18.html">Daily_Briefing_2025_03_18.html</a>
+                    <a href="Daily_Briefing_2025_03_18.html">Daily_Briefing_2025_03_18.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_03_25.html">Daily_Briefing_2025_03_25.html</a>
+                    <a href="Daily_Briefing_2025_03_25.html">Daily_Briefing_2025_03_25.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_03_26.html">Daily_Briefing_2025_03_26.html</a>
+                    <a href="Daily_Briefing_2025_03_26.html">Daily_Briefing_2025_03_26.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_04_08.html">Daily_Briefing_2025_04_08.html</a>
+                    <a href="Daily_Briefing_2025_04_08.html">Daily_Briefing_2025_04_08.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_04_16.html">Daily_Briefing_2025_04_16.html</a>
+                    <a href="Daily_Briefing_2025_04_16.html">Daily_Briefing_2025_04_16.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_04_17.html">Daily_Briefing_2025_04_17.html</a>
+                    <a href="Daily_Briefing_2025_04_17.html">Daily_Briefing_2025_04_17.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_04_22.html">Daily_Briefing_2025_04_22.html</a>
+                    <a href="Daily_Briefing_2025_04_22.html">Daily_Briefing_2025_04_22.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_05_01.html">Daily_Briefing_2025_05_01.html</a>
+                    <a href="Daily_Briefing_2025_05_01.html">Daily_Briefing_2025_05_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_05_02.html">Daily_Briefing_2025_05_02.html</a>
+                    <a href="Daily_Briefing_2025_05_02.html">Daily_Briefing_2025_05_02.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_05_07.html">Daily_Briefing_2025_05_07.html</a>
+                    <a href="Daily_Briefing_2025_05_07.html">Daily_Briefing_2025_05_07.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_05_15.html">Daily_Briefing_2025_05_15.html</a>
+                    <a href="Daily_Briefing_2025_05_15.html">Daily_Briefing_2025_05_15.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_05_20.html">Daily_Briefing_2025_05_20.html</a>
+                    <a href="Daily_Briefing_2025_05_20.html">Daily_Briefing_2025_05_20.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_05_26.html">Daily_Briefing_2025_05_26.html</a>
+                    <a href="Daily_Briefing_2025_05_26.html">Daily_Briefing_2025_05_26.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_06_06.html">Daily_Briefing_2025_06_06.html</a>
+                    <a href="Daily_Briefing_2025_06_06.html">Daily_Briefing_2025_06_06.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_06_10.html">Daily_Briefing_2025_06_10.html</a>
+                    <a href="Daily_Briefing_2025_06_10.html">Daily_Briefing_2025_06_10.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_06_13.html">Daily_Briefing_2025_06_13.html</a>
+                    <a href="Daily_Briefing_2025_06_13.html">Daily_Briefing_2025_06_13.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_06_16.html">Daily_Briefing_2025_06_16.html</a>
+                    <a href="Daily_Briefing_2025_06_16.html">Daily_Briefing_2025_06_16.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_06_18.html">Daily_Briefing_2025_06_18.html</a>
+                    <a href="Daily_Briefing_2025_06_18.html">Daily_Briefing_2025_06_18.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_06_24.html">Daily_Briefing_2025_06_24.html</a>
+                    <a href="Daily_Briefing_2025_06_24.html">Daily_Briefing_2025_06_24.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_07_04.html">Daily_Briefing_2025_07_04.html</a>
+                    <a href="Daily_Briefing_2025_07_04.html">Daily_Briefing_2025_07_04.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_07_09.html">Daily_Briefing_2025_07_09.html</a>
+                    <a href="Daily_Briefing_2025_07_09.html">Daily_Briefing_2025_07_09.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_07_15.html">Daily_Briefing_2025_07_15.html</a>
+                    <a href="Daily_Briefing_2025_07_15.html">Daily_Briefing_2025_07_15.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_07_18.html">Daily_Briefing_2025_07_18.html</a>
+                    <a href="Daily_Briefing_2025_07_18.html">Daily_Briefing_2025_07_18.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_07_22.html">Daily_Briefing_2025_07_22.html</a>
+                    <a href="Daily_Briefing_2025_07_22.html">Daily_Briefing_2025_07_22.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_07_24.html">Daily_Briefing_2025_07_24.html</a>
+                    <a href="Daily_Briefing_2025_07_24.html">Daily_Briefing_2025_07_24.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_07_25.html">Daily_Briefing_2025_07_25.html</a>
+                    <a href="Daily_Briefing_2025_07_25.html">Daily_Briefing_2025_07_25.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_07_30.html">Daily_Briefing_2025_07_30.html</a>
+                    <a href="Daily_Briefing_2025_07_30.html">Daily_Briefing_2025_07_30.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_08_01.html">Daily_Briefing_2025_08_01.html</a>
+                    <a href="Daily_Briefing_2025_08_01.html">Daily_Briefing_2025_08_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_08_05.html">Daily_Briefing_2025_08_05.html</a>
+                    <a href="Daily_Briefing_2025_08_05.html">Daily_Briefing_2025_08_05.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_08_07.html">Daily_Briefing_2025_08_07.html</a>
+                    <a href="Daily_Briefing_2025_08_07.html">Daily_Briefing_2025_08_07.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_08_15.html">Daily_Briefing_2025_08_15.html</a>
+                    <a href="Daily_Briefing_2025_08_15.html">Daily_Briefing_2025_08_15.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_08_18.html">Daily_Briefing_2025_08_18.html</a>
+                    <a href="Daily_Briefing_2025_08_18.html">Daily_Briefing_2025_08_18.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_08_20.html">Daily_Briefing_2025_08_20.html</a>
+                    <a href="Daily_Briefing_2025_08_20.html">Daily_Briefing_2025_08_20.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_08_22.html">Daily_Briefing_2025_08_22.html</a>
+                    <a href="Daily_Briefing_2025_08_22.html">Daily_Briefing_2025_08_22.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_08_27.html">Daily_Briefing_2025_08_27.html</a>
+                    <a href="Daily_Briefing_2025_08_27.html">Daily_Briefing_2025_08_27.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_09_01.html">Daily_Briefing_2025_09_01.html</a>
+                    <a href="Daily_Briefing_2025_09_01.html">Daily_Briefing_2025_09_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_09_03.html">Daily_Briefing_2025_09_03.html</a>
+                    <a href="Daily_Briefing_2025_09_03.html">Daily_Briefing_2025_09_03.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_09_08.html">Daily_Briefing_2025_09_08.html</a>
+                    <a href="Daily_Briefing_2025_09_08.html">Daily_Briefing_2025_09_08.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_09_17.html">Daily_Briefing_2025_09_17.html</a>
+                    <a href="Daily_Briefing_2025_09_17.html">Daily_Briefing_2025_09_17.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_09_19.html">Daily_Briefing_2025_09_19.html</a>
+                    <a href="Daily_Briefing_2025_09_19.html">Daily_Briefing_2025_09_19.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_09_29.html">Daily_Briefing_2025_09_29.html</a>
+                    <a href="Daily_Briefing_2025_09_29.html">Daily_Briefing_2025_09_29.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_10_15.html">Daily_Briefing_2025_10_15.html</a>
+                    <a href="Daily_Briefing_2025_10_15.html">Daily_Briefing_2025_10_15.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_10_16.html">Daily_Briefing_2025_10_16.html</a>
+                    <a href="Daily_Briefing_2025_10_16.html">Daily_Briefing_2025_10_16.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_10_28.html">Daily_Briefing_2025_10_28.html</a>
+                    <a href="Daily_Briefing_2025_10_28.html">Daily_Briefing_2025_10_28.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_11_04.html">Daily_Briefing_2025_11_04.html</a>
+                    <a href="Daily_Briefing_2025_11_04.html">Daily_Briefing_2025_11_04.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_11_06.html">Daily_Briefing_2025_11_06.html</a>
+                    <a href="Daily_Briefing_2025_11_06.html">Daily_Briefing_2025_11_06.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_11_10.html">Daily_Briefing_2025_11_10.html</a>
+                    <a href="Daily_Briefing_2025_11_10.html">Daily_Briefing_2025_11_10.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_11_19.html">Daily_Briefing_2025_11_19.html</a>
+                    <a href="Daily_Briefing_2025_11_19.html">Daily_Briefing_2025_11_19.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_11_25.html">Daily_Briefing_2025_11_25.html</a>
+                    <a href="Daily_Briefing_2025_11_25.html">Daily_Briefing_2025_11_25.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_11_27.html">Daily_Briefing_2025_11_27.html</a>
+                    <a href="Daily_Briefing_2025_11_27.html">Daily_Briefing_2025_11_27.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_12_09.html">Daily_Briefing_2025_12_09.html</a>
+                    <a href="Daily_Briefing_2025_12_09.html">Daily_Briefing_2025_12_09.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_12_15.html">Daily_Briefing_2025_12_15.html</a>
+                    <a href="Daily_Briefing_2025_12_15.html">Daily_Briefing_2025_12_15.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2025_12_23.html">Daily_Briefing_2025_12_23.html</a>
+                    <a href="Daily_Briefing_2025_12_23.html">Daily_Briefing_2025_12_23.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_01_12.html">Daily_Briefing_2026_01_12.html</a>
+                    <a href="Daily_Briefing_2026_01_12.html">Daily_Briefing_2026_01_12.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_01_20.html">Daily_Briefing_2026_01_20.html</a>
+                    <a href="Daily_Briefing_2026_01_20.html">Daily_Briefing_2026_01_20.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_01_23.html">Daily_Briefing_2026_01_23.html</a>
+                    <a href="Daily_Briefing_2026_01_23.html">Daily_Briefing_2026_01_23.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_01_26.html">Daily_Briefing_2026_01_26.html</a>
+                    <a href="Daily_Briefing_2026_01_26.html">Daily_Briefing_2026_01_26.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_01_30.html">Daily_Briefing_2026_01_30.html</a>
+                    <a href="Daily_Briefing_2026_01_30.html">Daily_Briefing_2026_01_30.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_02_02.html">Daily_Briefing_2026_02_02.html</a>
+                    <a href="Daily_Briefing_2026_02_02.html">Daily_Briefing_2026_02_02.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_02_04.html">Daily_Briefing_2026_02_04.html</a>
+                    <a href="Daily_Briefing_2026_02_04.html">Daily_Briefing_2026_02_04.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_02_05.html">Daily_Briefing_2026_02_05.html</a>
+                    <a href="Daily_Briefing_2026_02_05.html">Daily_Briefing_2026_02_05.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_02_09.html">Daily_Briefing_2026_02_09.html</a>
+                    <a href="Daily_Briefing_2026_02_09.html">Daily_Briefing_2026_02_09.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_02_13.html">Daily_Briefing_2026_02_13.html</a>
+                    <a href="Daily_Briefing_2026_02_13.html">Daily_Briefing_2026_02_13.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_02_16.html">Daily_Briefing_2026_02_16.html</a>
+                    <a href="Daily_Briefing_2026_02_16.html">Daily_Briefing_2026_02_16.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_02_17.html">Daily_Briefing_2026_02_17.html</a>
+                    <a href="Daily_Briefing_2026_02_17.html">Daily_Briefing_2026_02_17.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_02_19.html">Daily_Briefing_2026_02_19.html</a>
+                    <a href="Daily_Briefing_2026_02_19.html">Daily_Briefing_2026_02_19.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_03_03.html">Daily_Briefing_2026_03_03.html</a>
+                    <a href="Daily_Briefing_2026_03_03.html">Daily_Briefing_2026_03_03.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_03_06.html">Daily_Briefing_2026_03_06.html</a>
+                    <a href="Daily_Briefing_2026_03_06.html">Daily_Briefing_2026_03_06.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_03_12.html">Daily_Briefing_2026_03_12.html</a>
+                    <a href="Daily_Briefing_2026_03_12.html">Daily_Briefing_2026_03_12.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_03_16.html">Daily_Briefing_2026_03_16.html</a>
+                    <a href="Daily_Briefing_2026_03_16.html">Daily_Briefing_2026_03_16.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_03_20.html">Daily_Briefing_2026_03_20.html</a>
+                    <a href="Daily_Briefing_2026_03_20.html">Daily_Briefing_2026_03_20.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_03_23.html">Daily_Briefing_2026_03_23.html</a>
+                    <a href="Daily_Briefing_2026_03_23.html">Daily_Briefing_2026_03_23.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_03_26.html">Daily_Briefing_2026_03_26.html</a>
+                    <a href="Daily_Briefing_2026_03_26.html">Daily_Briefing_2026_03_26.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Daily_Briefing_2026_03_27.html">Daily_Briefing_2026_03_27.html</a>
+                    <a href="Daily_Briefing_2026_03_27.html">Daily_Briefing_2026_03_27.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_20251210.html">House_View_20251210.html</a>
+                    <a href="House_View_20251210.html">House_View_20251210.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2025_01_01.html">House_View_2025_01_01.html</a>
+                    <a href="House_View_2025_01_01.html">House_View_2025_01_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2025_02_01.html">House_View_2025_02_01.html</a>
+                    <a href="House_View_2025_02_01.html">House_View_2025_02_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2025_03_01.html">House_View_2025_03_01.html</a>
+                    <a href="House_View_2025_03_01.html">House_View_2025_03_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2025_04_01.html">House_View_2025_04_01.html</a>
+                    <a href="House_View_2025_04_01.html">House_View_2025_04_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2025_05_01.html">House_View_2025_05_01.html</a>
+                    <a href="House_View_2025_05_01.html">House_View_2025_05_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2025_06_01.html">House_View_2025_06_01.html</a>
+                    <a href="House_View_2025_06_01.html">House_View_2025_06_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2025_07_01.html">House_View_2025_07_01.html</a>
+                    <a href="House_View_2025_07_01.html">House_View_2025_07_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2025_08_01.html">House_View_2025_08_01.html</a>
+                    <a href="House_View_2025_08_01.html">House_View_2025_08_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2025_09_01.html">House_View_2025_09_01.html</a>
+                    <a href="House_View_2025_09_01.html">House_View_2025_09_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2025_10_01.html">House_View_2025_10_01.html</a>
+                    <a href="House_View_2025_10_01.html">House_View_2025_10_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2025_11_01.html">House_View_2025_11_01.html</a>
+                    <a href="House_View_2025_11_01.html">House_View_2025_11_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2025_12_01.html">House_View_2025_12_01.html</a>
+                    <a href="House_View_2025_12_01.html">House_View_2025_12_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2026_01_01.html">House_View_2026_01_01.html</a>
+                    <a href="House_View_2026_01_01.html">House_View_2026_01_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2026_02_01.html">House_View_2026_02_01.html</a>
+                    <a href="House_View_2026_02_01.html">House_View_2026_02_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/House_View_2026_03_01.html">House_View_2026_03_01.html</a>
+                    <a href="House_View_2026_03_01.html">House_View_2026_03_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_01_03.html">Market_Pulse_2025_01_03.html</a>
+                    <a href="Market_Pulse_2025_01_03.html">Market_Pulse_2025_01_03.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_01_10.html">Market_Pulse_2025_01_10.html</a>
+                    <a href="Market_Pulse_2025_01_10.html">Market_Pulse_2025_01_10.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_01_17.html">Market_Pulse_2025_01_17.html</a>
+                    <a href="Market_Pulse_2025_01_17.html">Market_Pulse_2025_01_17.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_01_24.html">Market_Pulse_2025_01_24.html</a>
+                    <a href="Market_Pulse_2025_01_24.html">Market_Pulse_2025_01_24.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_01_31.html">Market_Pulse_2025_01_31.html</a>
+                    <a href="Market_Pulse_2025_01_31.html">Market_Pulse_2025_01_31.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_02_07.html">Market_Pulse_2025_02_07.html</a>
+                    <a href="Market_Pulse_2025_02_07.html">Market_Pulse_2025_02_07.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_02_14.html">Market_Pulse_2025_02_14.html</a>
+                    <a href="Market_Pulse_2025_02_14.html">Market_Pulse_2025_02_14.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_02_21.html">Market_Pulse_2025_02_21.html</a>
+                    <a href="Market_Pulse_2025_02_21.html">Market_Pulse_2025_02_21.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_02_28.html">Market_Pulse_2025_02_28.html</a>
+                    <a href="Market_Pulse_2025_02_28.html">Market_Pulse_2025_02_28.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_03_07.html">Market_Pulse_2025_03_07.html</a>
+                    <a href="Market_Pulse_2025_03_07.html">Market_Pulse_2025_03_07.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_03_14.html">Market_Pulse_2025_03_14.html</a>
+                    <a href="Market_Pulse_2025_03_14.html">Market_Pulse_2025_03_14.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_03_21.html">Market_Pulse_2025_03_21.html</a>
+                    <a href="Market_Pulse_2025_03_21.html">Market_Pulse_2025_03_21.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_03_28.html">Market_Pulse_2025_03_28.html</a>
+                    <a href="Market_Pulse_2025_03_28.html">Market_Pulse_2025_03_28.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_04_04.html">Market_Pulse_2025_04_04.html</a>
+                    <a href="Market_Pulse_2025_04_04.html">Market_Pulse_2025_04_04.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_04_11.html">Market_Pulse_2025_04_11.html</a>
+                    <a href="Market_Pulse_2025_04_11.html">Market_Pulse_2025_04_11.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_04_18.html">Market_Pulse_2025_04_18.html</a>
+                    <a href="Market_Pulse_2025_04_18.html">Market_Pulse_2025_04_18.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_04_25.html">Market_Pulse_2025_04_25.html</a>
+                    <a href="Market_Pulse_2025_04_25.html">Market_Pulse_2025_04_25.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_05_02.html">Market_Pulse_2025_05_02.html</a>
+                    <a href="Market_Pulse_2025_05_02.html">Market_Pulse_2025_05_02.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_05_09.html">Market_Pulse_2025_05_09.html</a>
+                    <a href="Market_Pulse_2025_05_09.html">Market_Pulse_2025_05_09.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_05_16.html">Market_Pulse_2025_05_16.html</a>
+                    <a href="Market_Pulse_2025_05_16.html">Market_Pulse_2025_05_16.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_05_23.html">Market_Pulse_2025_05_23.html</a>
+                    <a href="Market_Pulse_2025_05_23.html">Market_Pulse_2025_05_23.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_05_30.html">Market_Pulse_2025_05_30.html</a>
+                    <a href="Market_Pulse_2025_05_30.html">Market_Pulse_2025_05_30.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_06_06.html">Market_Pulse_2025_06_06.html</a>
+                    <a href="Market_Pulse_2025_06_06.html">Market_Pulse_2025_06_06.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_06_13.html">Market_Pulse_2025_06_13.html</a>
+                    <a href="Market_Pulse_2025_06_13.html">Market_Pulse_2025_06_13.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_06_20.html">Market_Pulse_2025_06_20.html</a>
+                    <a href="Market_Pulse_2025_06_20.html">Market_Pulse_2025_06_20.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_06_27.html">Market_Pulse_2025_06_27.html</a>
+                    <a href="Market_Pulse_2025_06_27.html">Market_Pulse_2025_06_27.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_07_04.html">Market_Pulse_2025_07_04.html</a>
+                    <a href="Market_Pulse_2025_07_04.html">Market_Pulse_2025_07_04.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_07_11.html">Market_Pulse_2025_07_11.html</a>
+                    <a href="Market_Pulse_2025_07_11.html">Market_Pulse_2025_07_11.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_07_18.html">Market_Pulse_2025_07_18.html</a>
+                    <a href="Market_Pulse_2025_07_18.html">Market_Pulse_2025_07_18.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_07_25.html">Market_Pulse_2025_07_25.html</a>
+                    <a href="Market_Pulse_2025_07_25.html">Market_Pulse_2025_07_25.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_08_01.html">Market_Pulse_2025_08_01.html</a>
+                    <a href="Market_Pulse_2025_08_01.html">Market_Pulse_2025_08_01.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_08_08.html">Market_Pulse_2025_08_08.html</a>
+                    <a href="Market_Pulse_2025_08_08.html">Market_Pulse_2025_08_08.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_08_15.html">Market_Pulse_2025_08_15.html</a>
+                    <a href="Market_Pulse_2025_08_15.html">Market_Pulse_2025_08_15.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_08_22.html">Market_Pulse_2025_08_22.html</a>
+                    <a href="Market_Pulse_2025_08_22.html">Market_Pulse_2025_08_22.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_08_29.html">Market_Pulse_2025_08_29.html</a>
+                    <a href="Market_Pulse_2025_08_29.html">Market_Pulse_2025_08_29.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_09_05.html">Market_Pulse_2025_09_05.html</a>
+                    <a href="Market_Pulse_2025_09_05.html">Market_Pulse_2025_09_05.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_09_12.html">Market_Pulse_2025_09_12.html</a>
+                    <a href="Market_Pulse_2025_09_12.html">Market_Pulse_2025_09_12.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_09_19.html">Market_Pulse_2025_09_19.html</a>
+                    <a href="Market_Pulse_2025_09_19.html">Market_Pulse_2025_09_19.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_09_26.html">Market_Pulse_2025_09_26.html</a>
+                    <a href="Market_Pulse_2025_09_26.html">Market_Pulse_2025_09_26.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_10_03.html">Market_Pulse_2025_10_03.html</a>
+                    <a href="Market_Pulse_2025_10_03.html">Market_Pulse_2025_10_03.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_10_10.html">Market_Pulse_2025_10_10.html</a>
+                    <a href="Market_Pulse_2025_10_10.html">Market_Pulse_2025_10_10.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_10_17.html">Market_Pulse_2025_10_17.html</a>
+                    <a href="Market_Pulse_2025_10_17.html">Market_Pulse_2025_10_17.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_10_24.html">Market_Pulse_2025_10_24.html</a>
+                    <a href="Market_Pulse_2025_10_24.html">Market_Pulse_2025_10_24.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_10_31.html">Market_Pulse_2025_10_31.html</a>
+                    <a href="Market_Pulse_2025_10_31.html">Market_Pulse_2025_10_31.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_11_07.html">Market_Pulse_2025_11_07.html</a>
+                    <a href="Market_Pulse_2025_11_07.html">Market_Pulse_2025_11_07.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_11_14.html">Market_Pulse_2025_11_14.html</a>
+                    <a href="Market_Pulse_2025_11_14.html">Market_Pulse_2025_11_14.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_11_21.html">Market_Pulse_2025_11_21.html</a>
+                    <a href="Market_Pulse_2025_11_21.html">Market_Pulse_2025_11_21.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_11_28.html">Market_Pulse_2025_11_28.html</a>
+                    <a href="Market_Pulse_2025_11_28.html">Market_Pulse_2025_11_28.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_12_05.html">Market_Pulse_2025_12_05.html</a>
+                    <a href="Market_Pulse_2025_12_05.html">Market_Pulse_2025_12_05.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_12_12.html">Market_Pulse_2025_12_12.html</a>
+                    <a href="Market_Pulse_2025_12_12.html">Market_Pulse_2025_12_12.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_12_19.html">Market_Pulse_2025_12_19.html</a>
+                    <a href="Market_Pulse_2025_12_19.html">Market_Pulse_2025_12_19.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2025_12_26.html">Market_Pulse_2025_12_26.html</a>
+                    <a href="Market_Pulse_2025_12_26.html">Market_Pulse_2025_12_26.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_01_02.html">Market_Pulse_2026_01_02.html</a>
+                    <a href="Market_Pulse_2026_01_02.html">Market_Pulse_2026_01_02.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_01_09.html">Market_Pulse_2026_01_09.html</a>
+                    <a href="Market_Pulse_2026_01_09.html">Market_Pulse_2026_01_09.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_01_16.html">Market_Pulse_2026_01_16.html</a>
+                    <a href="Market_Pulse_2026_01_16.html">Market_Pulse_2026_01_16.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_01_23.html">Market_Pulse_2026_01_23.html</a>
+                    <a href="Market_Pulse_2026_01_23.html">Market_Pulse_2026_01_23.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_01_30.html">Market_Pulse_2026_01_30.html</a>
+                    <a href="Market_Pulse_2026_01_30.html">Market_Pulse_2026_01_30.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_02_06.html">Market_Pulse_2026_02_06.html</a>
+                    <a href="Market_Pulse_2026_02_06.html">Market_Pulse_2026_02_06.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_02_13.html">Market_Pulse_2026_02_13.html</a>
+                    <a href="Market_Pulse_2026_02_13.html">Market_Pulse_2026_02_13.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_02_20.html">Market_Pulse_2026_02_20.html</a>
+                    <a href="Market_Pulse_2026_02_20.html">Market_Pulse_2026_02_20.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_02_27.html">Market_Pulse_2026_02_27.html</a>
+                    <a href="Market_Pulse_2026_02_27.html">Market_Pulse_2026_02_27.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_03_06.html">Market_Pulse_2026_03_06.html</a>
+                    <a href="Market_Pulse_2026_03_06.html">Market_Pulse_2026_03_06.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_03_13.html">Market_Pulse_2026_03_13.html</a>
+                    <a href="Market_Pulse_2026_03_13.html">Market_Pulse_2026_03_13.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_03_20.html">Market_Pulse_2026_03_20.html</a>
+                    <a href="Market_Pulse_2026_03_20.html">Market_Pulse_2026_03_20.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/Market_Pulse_2026_03_27.html">Market_Pulse_2026_03_27.html</a>
+                    <a href="Market_Pulse_2026_03_27.html">Market_Pulse_2026_03_27.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/market_mayhem_archive_v23.html">market_mayhem_archive_v23.html</a>
+                    <a href="deprecated_archive/market_mayhem_archive_v23.html">market_mayhem_archive_v23.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/market_mayhem_archive_v235.html">market_mayhem_archive_v235.html</a>
+                    <a href="deprecated_archive/market_mayhem_archive_v235.html">market_mayhem_archive_v235.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/market_mayhem_archive_v24.html">market_mayhem_archive_v24.html</a>
+                    <a href="deprecated_archive/market_mayhem_archive_v24.html">market_mayhem_archive_v24.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/market_mayhem_conviction.html">market_mayhem_conviction.html</a>
+                    <a href="market_mayhem_conviction.html">market_mayhem_conviction.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/market_mayhem_rebuild.html">market_mayhem_rebuild.html</a>
+                    <a href="market_mayhem_rebuild.html">market_mayhem_rebuild.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_2025_02_07.html">newsletter_2025_02_07.html</a>
+                    <a href="newsletter_2025_02_07.html">newsletter_2025_02_07.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_2025_02_14.html">newsletter_2025_02_14.html</a>
+                    <a href="newsletter_2025_02_14.html">newsletter_2025_02_14.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_2025_02_21.html">newsletter_2025_02_21.html</a>
+                    <a href="newsletter_2025_02_21.html">newsletter_2025_02_21.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_2025_03_03.html">newsletter_2025_03_03.html</a>
+                    <a href="newsletter_2025_03_03.html">newsletter_2025_03_03.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_flash_nov_01_2025.html">newsletter_flash_nov_01_2025.html</a>
+                    <a href="newsletter_flash_nov_01_2025.html">newsletter_flash_nov_01_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem.html">newsletter_market_mayhem.html</a>
+                    <a href="newsletter_market_mayhem.html">newsletter_market_mayhem.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_apr_04_2025.html">newsletter_market_mayhem_apr_04_2025.html</a>
+                    <a href="newsletter_market_mayhem_apr_04_2025.html">newsletter_market_mayhem_apr_04_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_apr_2025.html">newsletter_market_mayhem_apr_2025.html</a>
+                    <a href="newsletter_market_mayhem_apr_2025.html">newsletter_market_mayhem_apr_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_aug_2025.html">newsletter_market_mayhem_aug_2025.html</a>
+                    <a href="newsletter_market_mayhem_aug_2025.html">newsletter_market_mayhem_aug_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_aug_29_2025.html">newsletter_market_mayhem_aug_29_2025.html</a>
+                    <a href="newsletter_market_mayhem_aug_29_2025.html">newsletter_market_mayhem_aug_29_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_dec_02_2025.html">newsletter_market_mayhem_dec_02_2025.html</a>
+                    <a href="newsletter_market_mayhem_dec_02_2025.html">newsletter_market_mayhem_dec_02_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_dec_2024.html">newsletter_market_mayhem_dec_2024.html</a>
+                    <a href="newsletter_market_mayhem_dec_2024.html">newsletter_market_mayhem_dec_2024.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_feb_01_2026.html">newsletter_market_mayhem_feb_01_2026.html</a>
+                    <a href="newsletter_market_mayhem_feb_01_2026.html">newsletter_market_mayhem_feb_01_2026.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_feb_02_2026.html">newsletter_market_mayhem_feb_02_2026.html</a>
+                    <a href="newsletter_market_mayhem_feb_02_2026.html">newsletter_market_mayhem_feb_02_2026.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_feb_06_2026.html">newsletter_market_mayhem_feb_06_2026.html</a>
+                    <a href="newsletter_market_mayhem_feb_06_2026.html">newsletter_market_mayhem_feb_06_2026.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_feb_09_2026.html">newsletter_market_mayhem_feb_09_2026.html</a>
+                    <a href="newsletter_market_mayhem_feb_09_2026.html">newsletter_market_mayhem_feb_09_2026.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_feb_13_2026.html">newsletter_market_mayhem_feb_13_2026.html</a>
+                    <a href="newsletter_market_mayhem_feb_13_2026.html">newsletter_market_mayhem_feb_13_2026.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_feb_14_2026.html">newsletter_market_mayhem_feb_14_2026.html</a>
+                    <a href="newsletter_market_mayhem_feb_14_2026.html">newsletter_market_mayhem_feb_14_2026.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_feb_16_2026.html">newsletter_market_mayhem_feb_16_2026.html</a>
+                    <a href="newsletter_market_mayhem_feb_16_2026.html">newsletter_market_mayhem_feb_16_2026.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_feb_2025.html">newsletter_market_mayhem_feb_2025.html</a>
+                    <a href="newsletter_market_mayhem_feb_2025.html">newsletter_market_mayhem_feb_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_jan_14_2026.html">newsletter_market_mayhem_jan_14_2026.html</a>
+                    <a href="newsletter_market_mayhem_jan_14_2026.html">newsletter_market_mayhem_jan_14_2026.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_jan_2025.html">newsletter_market_mayhem_jan_2025.html</a>
+                    <a href="newsletter_market_mayhem_jan_2025.html">newsletter_market_mayhem_jan_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_jan_2026.html">newsletter_market_mayhem_jan_2026.html</a>
+                    <a href="newsletter_market_mayhem_jan_2026.html">newsletter_market_mayhem_jan_2026.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_jan_31_2026.html">newsletter_market_mayhem_jan_31_2026.html</a>
+                    <a href="newsletter_market_mayhem_jan_31_2026.html">newsletter_market_mayhem_jan_31_2026.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_jul_2025.html">newsletter_market_mayhem_jul_2025.html</a>
+                    <a href="newsletter_market_mayhem_jul_2025.html">newsletter_market_mayhem_jul_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_jul_2025_v2.html">newsletter_market_mayhem_jul_2025_v2.html</a>
+                    <a href="newsletter_market_mayhem_jul_2025_v2.html">newsletter_market_mayhem_jul_2025_v2.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_jun_2022.html">newsletter_market_mayhem_jun_2022.html</a>
+                    <a href="newsletter_market_mayhem_jun_2022.html">newsletter_market_mayhem_jun_2022.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_jun_2025.html">newsletter_market_mayhem_jun_2025.html</a>
+                    <a href="newsletter_market_mayhem_jun_2025.html">newsletter_market_mayhem_jun_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_jun_29_2025.html">newsletter_market_mayhem_jun_29_2025.html</a>
+                    <a href="newsletter_market_mayhem_jun_29_2025.html">newsletter_market_mayhem_jun_29_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_mar_15_2026.html">newsletter_market_mayhem_mar_15_2026.html</a>
+                    <a href="newsletter_market_mayhem_mar_15_2026.html">newsletter_market_mayhem_mar_15_2026.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_mar_2000.html">newsletter_market_mayhem_mar_2000.html</a>
+                    <a href="newsletter_market_mayhem_mar_2000.html">newsletter_market_mayhem_mar_2000.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_mar_2020.html">newsletter_market_mayhem_mar_2020.html</a>
+                    <a href="newsletter_market_mayhem_mar_2020.html">newsletter_market_mayhem_mar_2020.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_mar_2025.html">newsletter_market_mayhem_mar_2025.html</a>
+                    <a href="newsletter_market_mayhem_mar_2025.html">newsletter_market_mayhem_mar_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_mar_2026.html">newsletter_market_mayhem_mar_2026.html</a>
+                    <a href="newsletter_market_mayhem_mar_2026.html">newsletter_market_mayhem_mar_2026.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_may_02_2025.html">newsletter_market_mayhem_may_02_2025.html</a>
+                    <a href="newsletter_market_mayhem_may_02_2025.html">newsletter_market_mayhem_may_02_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_may_2025.html">newsletter_market_mayhem_may_2025.html</a>
+                    <a href="newsletter_market_mayhem_may_2025.html">newsletter_market_mayhem_may_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_nov.html">newsletter_market_mayhem_nov.html</a>
+                    <a href="newsletter_market_mayhem_nov.html">newsletter_market_mayhem_nov.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_nov_13_2025.html">newsletter_market_mayhem_nov_13_2025.html</a>
+                    <a href="newsletter_market_mayhem_nov_13_2025.html">newsletter_market_mayhem_nov_13_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_oct.html">newsletter_market_mayhem_oct.html</a>
+                    <a href="newsletter_market_mayhem_oct.html">newsletter_market_mayhem_oct.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_oct_1929.html">newsletter_market_mayhem_oct_1929.html</a>
+                    <a href="newsletter_market_mayhem_oct_1929.html">newsletter_market_mayhem_oct_1929.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_oct_1987.html">newsletter_market_mayhem_oct_1987.html</a>
+                    <a href="newsletter_market_mayhem_oct_1987.html">newsletter_market_mayhem_oct_1987.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_oct_2025.html">newsletter_market_mayhem_oct_2025.html</a>
+                    <a href="newsletter_market_mayhem_oct_2025.html">newsletter_market_mayhem_oct_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_oct_31_2025.html">newsletter_market_mayhem_oct_31_2025.html</a>
+                    <a href="newsletter_market_mayhem_oct_31_2025.html">newsletter_market_mayhem_oct_31_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_sep_19_2025.html">newsletter_market_mayhem_sep_19_2025.html</a>
+                    <a href="newsletter_market_mayhem_sep_19_2025.html">newsletter_market_mayhem_sep_19_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_sep_2008.html">newsletter_market_mayhem_sep_2008.html</a>
+                    <a href="newsletter_market_mayhem_sep_2008.html">newsletter_market_mayhem_sep_2008.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_sep_2025.html">newsletter_market_mayhem_sep_2025.html</a>
+                    <a href="newsletter_market_mayhem_sep_2025.html">newsletter_market_mayhem_sep_2025.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_market_mayhem_special_edition.html">newsletter_market_mayhem_special_edition.html</a>
+                    <a href="newsletter_market_mayhem_special_edition.html">newsletter_market_mayhem_special_edition.html</a>
                 </li>
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="../exports/market_mayhem/newsletter_weekly_sep_21_2025.html">newsletter_weekly_sep_21_2025.html</a>
+                    <a href="newsletter_weekly_sep_21_2025.html">newsletter_weekly_sep_21_2025.html</a>
                 </li>
 
             </ul>
@@ -3787,7 +3787,7 @@
 
                 <li class="file-item">
                     <span class="file-icon">📄</span>
-                    <a href="market_mayhem_archive_v24.html">market_mayhem_archive_v24.html</a>
+                    <a href="deprecated_archive/market_mayhem_archive_v24.html">market_mayhem_archive_v24.html</a>
                 </li>
 
                 <li class="file-item">

--- a/showcase/deprecated_archive/market_mayhem_archive_v21.html
+++ b/showcase/deprecated_archive/market_mayhem_archive_v21.html
@@ -4214,7 +4214,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">Q1 2025 and Full Year Outlook: Navigating a Bifurcated Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">The first quarter of 2025 has presented a bifurcated market landscape, characterized by diverging trends across sectors and regions. While some sectors, such as technology and healthcare, have shown c...</p>
                 </div>
-                <a href="Q1 2025 and Full Year Outlook - Navigating a Bifurcated Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="Q1_2025_and_Full_Year_Outlook_-_Navigating_a_Bifurcated_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="house view: ai application boom outlook strategic allocation update for april 2025. the ai application boom remains the dominant macro driver....">
@@ -5412,7 +5412,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2024 Year in Review: Navigating Uncertainty and Transition</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">2024 was a year of uncertainty and transition for the financial markets. After a strong recovery in 2023, market volatility increased as investors grappled with mixed economic signals, geopolitical ri...</p>
                 </div>
-                <a href="2024 Year in Review - Navigating Uncertainty and Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2024_Year_in_Review_-_Navigating_Uncertainty_and_Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="house view: tech correction outlook strategic allocation update for january 2025. the tech correction remains the dominant macro driver....">
@@ -5802,7 +5802,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2023 Year in Review: A Year of Recovery and Resilience</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="2023 Year in Review - A Year of Recovery and Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2023_Year_in_Review_-_A_Year_of_Recovery_and_Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="analytics hub report content.">
@@ -5880,7 +5880,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2022 Year in Review: Navigating a Turbulent Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="2022 Year in Review - Navigating a Turbulent Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2022_Year_in_Review_-_Navigating_a_Turbulent_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="untitled report report content.">
@@ -6465,7 +6465,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2024 Year in Review: Navigating Uncertainty and Transition</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="2024 Year in Review - Navigating Uncertainty and Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2024_Year_in_Review_-_Navigating_Uncertainty_and_Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="cyber-financial wargame console report content.">
@@ -7245,7 +7245,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">Q1 2025 and Full Year Outlook: Navigating a Bifurcated Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="Q1 2025 and Full Year Outlook - Navigating a Bifurcated Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="Q1_2025_and_Full_Year_Outlook_-_Navigating_a_Bifurcated_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="avg distressed credit pricing console report content.">
@@ -7518,7 +7518,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2023 Year in Review: A Year of Recovery and Resilience</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">2023 proved to be a year of recovery and resilience for the financial markets.  After a challenging 2022, major stock indices rebounded, with the S&P 500 gaining approximately 20%. The technology sect...</p>
                 </div>
-                <a href="2023 Year in Review - A Year of Recovery and Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2023_Year_in_Review_-_A_Year_of_Recovery_and_Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-HISTORICAL" data-year="HISTORICAL" data-type="HISTORICAL" data-title="market mayhem: regional banking crisis &quot;bank run speed run&quot;. silicon valley bank (svb) has collapsed, marking the second-largest bank failure in us history. contagion fears are spreading to signature bank and first republic.">
@@ -7544,7 +7544,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2022 Year in Review: Navigating a Turbulent Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">2022 was a challenging year for investors, marked by heightened volatility, rising inflation, and geopolitical tensions. Major stock indices experienced significant declines, with the S&P 500 ending t...</p>
                 </div>
-                <a href="2022 Year in Review - Navigating a Turbulent Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2022_Year_in_Review_-_Navigating_a_Turbulent_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="HISTORICAL" data-type="NEWSLETTER" data-title="market mayhem market analysis.">

--- a/showcase/deprecated_archive/market_mayhem_archive_v23.html
+++ b/showcase/deprecated_archive/market_mayhem_archive_v23.html
@@ -2852,7 +2852,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">Q1 2025 and Full Year Outlook: Navigating a Bifurcated Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">The first quarter of 2025 has presented a bifurcated market landscape, characterized by diverging trends across sectors and regions. While some sectors, such as technology and healthcare, have shown c...</p>
                 </div>
-                <a href="Q1 2025 and Full Year Outlook - Navigating a Bifurcated Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="Q1_2025_and_Full_Year_Outlook_-_Navigating_a_Bifurcated_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="house view: ai application boom outlook strategic allocation update for april 2025. the ai application boom remains the dominant macro driver....">
@@ -3803,7 +3803,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2024 Year in Review: Navigating Uncertainty and Transition</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">2024 was a year of uncertainty and transition for the financial markets. After a strong recovery in 2023, market volatility increased as investors grappled with mixed economic signals, geopolitical ri...</p>
                 </div>
-                <a href="2024 Year in Review - Navigating Uncertainty and Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2024_Year_in_Review_-_Navigating_Uncertainty_and_Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="house view: tech correction outlook strategic allocation update for january 2025. the tech correction remains the dominant macro driver....">
@@ -4141,7 +4141,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2023 Year in Review: A Year of Recovery and Resilience</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="2023 Year in Review - A Year of Recovery and Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2023_Year_in_Review_-_A_Year_of_Recovery_and_Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-STRATEGY" data-year="2025" data-type="STRATEGY" data-title="confidential :: 70/30 mandate strategy report content.">
@@ -4206,7 +4206,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2022 Year in Review: Navigating a Turbulent Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="2022 Year in Review - Navigating a Turbulent Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2022_Year_in_Review_-_Navigating_a_Turbulent_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="untitled report report content.">
@@ -4661,7 +4661,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2024 Year in Review: Navigating Uncertainty and Transition</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="2024 Year in Review - Navigating Uncertainty and Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2024_Year_in_Review_-_Navigating_Uncertainty_and_Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="cyber-financial wargame console report content.">
@@ -5181,7 +5181,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">Q1 2025 and Full Year Outlook: Navigating a Bifurcated Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="Q1 2025 and Full Year Outlook - Navigating a Bifurcated Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="Q1_2025_and_Full_Year_Outlook_-_Navigating_a_Bifurcated_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="avg distressed credit pricing console report content.">
@@ -5376,7 +5376,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2023 Year in Review: A Year of Recovery and Resilience</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">2023 proved to be a year of recovery and resilience for the financial markets.  After a challenging 2022, major stock indices rebounded, with the S&P 500 gaining approximately 20%. The technology sect...</p>
                 </div>
-                <a href="2023 Year in Review - A Year of Recovery and Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2023_Year_in_Review_-_A_Year_of_Recovery_and_Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-MARKET_OUTLOOK" data-year="2023" data-type="MARKET_OUTLOOK" data-title="2022 year in review: navigating a turbulent market 2022 was a challenging year for investors, marked by heightened volatility, rising inflation, and geopolitical tensions. major stock indices experienced significant declines, with the s&p 500 ending t...">
@@ -5389,7 +5389,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2022 Year in Review: Navigating a Turbulent Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">2022 was a challenging year for investors, marked by heightened volatility, rising inflation, and geopolitical tensions. Major stock indices experienced significant declines, with the S&P 500 ending t...</p>
                 </div>
-                <a href="2022 Year in Review - Navigating a Turbulent Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2022_Year_in_Review_-_Navigating_a_Turbulent_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-NEWSLETTER" data-year="2022" data-type="NEWSLETTER" data-title="market mayhem market analysis.">

--- a/showcase/deprecated_archive/market_mayhem_archive_v235.html
+++ b/showcase/deprecated_archive/market_mayhem_archive_v235.html
@@ -2814,7 +2814,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">Q1 2025 and Full Year Outlook: Navigating a Bifurcated Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">The first quarter of 2025 has presented a bifurcated market landscape, characterized by diverging trends across sectors and regions. While some sectors, such as technology and healthcare, have shown c...</p>
                 </div>
-                <a href="Q1 2025 and Full Year Outlook - Navigating a Bifurcated Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="Q1_2025_and_Full_Year_Outlook_-_Navigating_a_Bifurcated_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="house view: ai application boom outlook strategic allocation update for april 2025. the ai application boom remains the dominant macro driver....">
@@ -3739,7 +3739,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2024 Year in Review: Navigating Uncertainty and Transition</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">2024 was a year of uncertainty and transition for the financial markets. After a strong recovery in 2023, market volatility increased as investors grappled with mixed economic signals, geopolitical ri...</p>
                 </div>
-                <a href="2024 Year in Review - Navigating Uncertainty and Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2024_Year_in_Review_-_Navigating_Uncertainty_and_Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="house view: tech correction outlook strategic allocation update for january 2025. the tech correction remains the dominant macro driver....">
@@ -4077,7 +4077,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2023 Year in Review: A Year of Recovery and Resilience</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="2023 Year in Review - A Year of Recovery and Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2023_Year_in_Review_-_A_Year_of_Recovery_and_Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-STRATEGY" data-year="2025" data-type="STRATEGY" data-title="confidential :: 70/30 mandate strategy report content.">
@@ -4142,7 +4142,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2022 Year in Review: Navigating a Turbulent Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="2022 Year in Review - Navigating a Turbulent Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2022_Year_in_Review_-_Navigating_a_Turbulent_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="untitled report report content.">
@@ -4597,7 +4597,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2024 Year in Review: Navigating Uncertainty and Transition</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="2024 Year in Review - Navigating Uncertainty and Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2024_Year_in_Review_-_Navigating_Uncertainty_and_Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="cyber-financial wargame console report content.">
@@ -5117,7 +5117,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">Q1 2025 and Full Year Outlook: Navigating a Bifurcated Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="Q1 2025 and Full Year Outlook - Navigating a Bifurcated Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="Q1_2025_and_Full_Year_Outlook_-_Navigating_a_Bifurcated_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="avg distressed credit pricing console report content.">
@@ -5312,7 +5312,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2023 Year in Review: A Year of Recovery and Resilience</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">2023 proved to be a year of recovery and resilience for the financial markets.  After a challenging 2022, major stock indices rebounded, with the S&P 500 gaining approximately 20%. The technology sect...</p>
                 </div>
-                <a href="2023 Year in Review - A Year of Recovery and Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2023_Year_in_Review_-_A_Year_of_Recovery_and_Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-MARKET_OUTLOOK" data-year="2023" data-type="MARKET_OUTLOOK" data-title="2022 year in review: navigating a turbulent market 2022 was a challenging year for investors, marked by heightened volatility, rising inflation, and geopolitical tensions. major stock indices experienced significant declines, with the s&p 500 ending t...">
@@ -5325,7 +5325,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2022 Year in Review: Navigating a Turbulent Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">2022 was a challenging year for investors, marked by heightened volatility, rising inflation, and geopolitical tensions. Major stock indices experienced significant declines, with the S&P 500 ending t...</p>
                 </div>
-                <a href="2022 Year in Review - Navigating a Turbulent Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2022_Year_in_Review_-_Navigating_a_Turbulent_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
             
             <div class="archive-item type-NEWSLETTER" data-year="2022" data-type="NEWSLETTER" data-title="market mayhem market analysis.">

--- a/showcase/deprecated_archive/market_mayhem_archive_v24.html
+++ b/showcase/deprecated_archive/market_mayhem_archive_v24.html
@@ -4294,7 +4294,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">Q1 2025 and Full Year Outlook: Navigating a Bifurcated Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">The first quarter of 2025 has presented a bifurcated market landscape, characterized by diverging trends across sectors and regions. While some sectors, such as technology and healthcare, have shown c...</p>
                 </div>
-                <a href="Q1 2025 and Full Year Outlook - Navigating a Bifurcated Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="Q1_2025_and_Full_Year_Outlook_-_Navigating_a_Bifurcated_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="house view: ai application boom outlook strategic allocation update for april 2025. the ai application boom remains the dominant macro driver...."
@@ -5584,7 +5584,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2024 Year in Review: Navigating Uncertainty and Transition</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">2024 was a year of uncertainty and transition for the financial markets. After a strong recovery in 2023, market volatility increased as investors grappled with mixed economic signals, geopolitical ri...</p>
                 </div>
-                <a href="2024 Year in Review - Navigating Uncertainty and Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2024_Year_in_Review_-_Navigating_Uncertainty_and_Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="house view: tech correction outlook strategic allocation update for january 2025. the tech correction remains the dominant macro driver...."
@@ -6004,7 +6004,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2023 Year in Review: A Year of Recovery and Resilience</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="2023 Year in Review - A Year of Recovery and Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2023_Year_in_Review_-_A_Year_of_Recovery_and_Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="adam v26.0 :: live market report content."
@@ -6116,7 +6116,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2022 Year in Review: Navigating a Turbulent Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="2022 Year in Review - Navigating a Turbulent Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2022_Year_in_Review_-_Navigating_a_Turbulent_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="untitled report report content."
@@ -6830,7 +6830,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2024 Year in Review: Navigating Uncertainty and Transition</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="2024 Year in Review - Navigating Uncertainty and Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2024_Year_in_Review_-_Navigating_Uncertainty_and_Transition.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="cyber-financial wargame console report content."
@@ -7838,7 +7838,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">Q1 2025 and Full Year Outlook: Navigating a Bifurcated Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">Report content.</p>
                 </div>
-                <a href="Q1 2025 and Full Year Outlook - Navigating a Bifurcated Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="Q1_2025_and_Full_Year_Outlook_-_Navigating_a_Bifurcated_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2025" data-type="NEWSLETTER" data-title="avg distressed credit pricing console report content."
@@ -8146,7 +8146,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2023 Year in Review: A Year of Recovery and Resilience</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">2023 proved to be a year of recovery and resilience for the financial markets.  After a challenging 2022, major stock indices rebounded, with the S&P 500 gaining approximately 20%. The technology sect...</p>
                 </div>
-                <a href="2023 Year in Review - A Year of Recovery and Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2023_Year_in_Review_-_A_Year_of_Recovery_and_Resilience.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-HISTORICAL" data-year="2023" data-type="HISTORICAL" data-title="market mayhem: regional banking crisis 'bank run speed run'. silicon valley bank (svb) has collapsed, marking the second-largest bank failure in us history. contagion fears are spreading to signature bank and first republic."
@@ -8174,7 +8174,7 @@ Hello Q2! The first quarter is in the books, and the bulls are clearly in charge
                     <h3 style="margin:0 0 5px 0; font-size:1.1rem;">2022 Year in Review: Navigating a Turbulent Market</h3>
                     <p style="margin:0; font-size:0.85rem; color:#aaa;">2022 was a challenging year for investors, marked by heightened volatility, rising inflation, and geopolitical tensions. Major stock indices experienced significant declines, with the S&P 500 ending t...</p>
                 </div>
-                <a href="2022 Year in Review - Navigating a Turbulent Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
+                <a href="2022_Year_in_Review_-_Navigating_a_Turbulent_Market.html" class="cyber-btn" style="align-self:center;">ACCESS</a>
             </div>
 
             <div class="archive-item type-NEWSLETTER" data-year="2022" data-type="NEWSLETTER" data-title="market mayhem market analysis."

--- a/showcase/nvda_company_report_20250226_final.html
+++ b/showcase/nvda_company_report_20250226_final.html
@@ -178,7 +178,7 @@
             <div class="sidebar-widget">
                 <div class="sidebar-title">Detected Entities</div>
                 <div class="tag-cloud">
-                    <a href="market_mayhem_archive.html?search=AI" class="tag" style="text-decoration:none; border-color:#666;">AI</a><a href="market_mayhem_archive.html?search=EV" class="tag" style="text-decoration:none; border-color:#666;">EV</a><a href="market_mayhem_archive.html?search=Growth" class="tag" style="text-decoration:none; border-color:#666;">Growth</a><a href="market_mayhem_archive.html?search=Supply Chain" class="tag" style="text-decoration:none; border-color:#666;">Supply Chain</a>
+                    <a href="market_mayhem_archive.html?search=AI" class="tag" style="text-decoration:none; border-color:#666;">AI</a><a href="market_mayhem_archive.html?search=EV" class="tag" style="text-decoration:none; border-color:#666;">EV</a><a href="market_mayhem_archive.html?search=Growth" class="tag" style="text-decoration:none; border-color:#666;">Growth</a><a href="market_mayhem_archive.html?search=Supply_Chain" class="tag" style="text-decoration:none; border-color:#666;">Supply Chain</a>
                 </div>
             </div>
 


### PR DESCRIPTION
This submission resolves 404 errors across the repository's showcase deployed on GitHub Pages. Several issues were fixed: 
- Paths pointing to a non-deployed `exports/market_mayhem/` directory were updated to local relative paths.
- Filename references containing spaces or colons were corrected to match the actual file paths containing underscores/hyphens.
- Archive file paths were correctly mapped to the `deprecated_archive/` subdirectory to resolve missing file references.

---
*PR created automatically by Jules for task [2164477232081344810](https://jules.google.com/task/2164477232081344810) started by @adamvangrover*