### PR TITLE
feat: Centralized Adam Daily visual hub in showcase index

### DIFF
--- a/showcase/adam_daily_hub_index.html
+++ b/showcase/adam_daily_hub_index.html
@@ -1,0 +1,1491 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ADAM-DAILY // ALL REPORTS HUB</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <script>
+        tailwind.config = {
+            darkMode: 'class',
+            theme: {
+                extend: {
+                    fontFamily: {
+                        sans: ['Inter', 'Segoe UI', 'sans-serif'],
+                        mono: ['Fira Code', 'ui-monospace', 'monospace'],
+                        display: ['Oswald', 'Inter', 'sans-serif'],
+                    },
+                    colors: {
+                        term: {
+                            bg: '#030712', surface: '#0f172a',
+                            cyan: '#06b6d4', red: '#ef4444', amber: '#f59e0b', green: '#10b981'
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;600&family=Inter:wght@300;400;600;800&family=Oswald:wght@500;700&display=swap');
+        body { font-family: 'Inter', sans-serif; background-color: #030712; color: #e2e8f0; }
+        h1, h2, h3, h4, h5, h6 { font-family: 'Oswald', sans-serif; text-transform: uppercase; }
+        .font-mono { font-family: 'Fira Code', monospace; }
+
+        .cyber-panel {
+            background: rgba(15, 23, 42, 0.6);
+            border: 1px solid rgba(255, 255, 255, 0.05);
+            backdrop-filter: blur(10px);
+        }
+
+        .timeline-line {
+            position: absolute;
+            left: 20px;
+            top: 0;
+            bottom: 0;
+            width: 2px;
+            background: linear-gradient(to bottom, #06b6d4, transparent);
+        }
+
+        .timeline-dot {
+            position: absolute;
+            left: 15px;
+            width: 12px;
+            height: 12px;
+            border-radius: 50%;
+            background-color: #030712;
+            border: 2px solid #06b6d4;
+        }
+    </style>
+</head>
+<body class="min-h-screen text-slate-300">
+    <div class="fixed inset-0 bg-[url('https://www.transparenttextures.com/patterns/stardust.png')] opacity-10 pointer-events-none z-0"></div>
+
+    <header class="sticky top-0 z-50 border-b border-white/10 bg-term-bg/80 backdrop-blur-md">
+        <div class="max-w-7xl mx-auto px-4 py-3 flex justify-between items-center">
+            <div class="flex items-center space-x-4">
+                <div class="w-8 h-8 bg-term-cyan/20 border border-term-cyan/50 flex items-center justify-center animate-pulse">
+                    <span class="text-term-cyan font-bold font-mono">A</span>
+                </div>
+                <h1 class="text-xl tracking-widest text-white">ADAM <span class="text-term-cyan">DAILY DIRECTORY</span></h1>
+            </div>
+            <a href="index.html" class="px-4 py-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded text-xs font-mono transition-colors">RETURN TO MAIN ARCHIVE</a>
+        </div>
+    </header>
+
+    <main class="max-w-7xl mx-auto px-4 py-12 relative z-10">
+        <div class="mb-12 border-l-2 border-term-cyan pl-6">
+            <h2 class="text-3xl text-white mb-2">COMPLETE INTELLIGENCE ARCHIVE</h2>
+            <p class="text-slate-400 font-mono text-sm max-w-2xl">
+                SYSTEM STATUS: <span class="text-term-green">ONLINE</span> | INDEXED DATES: 48 | LAST UPDATE: LIVE
+            </p>
+        </div>
+
+        <div class="relative pl-8 md:pl-12">
+            <div class="timeline-line"></div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-31</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-31/adam.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">adam.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-31/adam.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-31/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-31/daily_brief.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-30</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-30/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-30/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-30/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-30/daily_brief.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-28</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-28/apollo.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">apollo.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-28/apollo.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-28/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-28/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-28/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-28/daily_brief.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-27</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-27/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-27/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-27/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-27/daily_brief.md</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-27/prompt.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">prompt.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-27/prompt.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-26</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-26/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-26/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-26/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-26/daily_brief.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-24</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-24/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-24/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-24/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-24/daily_brief.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-23</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-23/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-23/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-23/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-23/daily_brief.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-22</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-22/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-22/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-22/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-22/daily_brief.md</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-22/entropy_intel.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">entropy_intel.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-22/entropy_intel.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-21</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-21/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-21/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-21/heatmap.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">heatmap.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-21/heatmap.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-21/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-21/daily_brief.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-20</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-20/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-20/daily_brief.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-19</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-19/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-19/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-19/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-19/daily_brief.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-18</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-18/brief.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">brief.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-18/brief.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-18/heatmap.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">heatmap.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-18/heatmap.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-18/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-18/daily_brief.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-17</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-17/interactive.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">interactive.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-17/interactive.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-17/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-17/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-17/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-17/daily_brief.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-16</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-16/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-16/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-16/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-16/daily_brief.md</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-16/mm_2026-05-16.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">mm_2026-05-16.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-16/mm_2026-05-16.md</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-16/mm_vOS.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">mm_vOS.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-16/mm_vOS.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-15</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-15/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-15/daily_brief.md</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-15/flow_report.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">flow_report.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-15/flow_report.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-14</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-14/mets.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">mets.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-14/mets.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-14/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-14/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-13</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-13/sim.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">sim.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-13/sim.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-13/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-13/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-13/daily_brief.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">daily_brief.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-13/daily_brief.md</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-13/prompt.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">prompt.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-13/prompt.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-11</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-11/update.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">update.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-11/update.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-11/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-11/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-10</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-10/update.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">update.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-10/update.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-10/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-10/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-09</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-09/index_vJULES.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_vJULES.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-09/index_vJULES.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-09/template.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">template.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-09/template.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-09/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-09/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-09/index_v55.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_v55.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-09/index_v55.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-08</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-08/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-08/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-07</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-07/index_vJULES.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_vJULES.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-07/index_vJULES.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-07/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-07/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-06</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-06/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-06/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-04</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-04/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-04/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-03</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-03/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-03/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-03/index_v55.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_v55.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-03/index_v55.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-02</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-02/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-02/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-05-01</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-05-01/index_v50.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_v50.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-01/index_v50.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-05-01/index_PM.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_PM.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-05-01/index_PM.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-30</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-30/index_vomni.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_vomni.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-30/index_vomni.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-30/index_vjson.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_vjson.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-30/index_vjson.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-30/index_os.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_os.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-30/index_os.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-30/index_desktop.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_desktop.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-30/index_desktop.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-30/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-30/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-30/index_WIP.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_WIP.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-30/index_WIP.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-29</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-29/index_v50.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_v50.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-29/index_v50.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-29/index_vAO.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_vAO.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-29/index_vAO.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-29/index_v260429.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_v260429.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-29/index_v260429.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-29/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-29/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-29/index_WIP.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_WIP.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-29/index_WIP.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-29/index1.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index1.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-29/index1.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-28</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-28/index_vOLD.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_vOLD.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-28/index_vOLD.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-28/index_v40.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_v40.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-28/index_v40.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-28/index_v50WIP.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_v50WIP.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-28/index_v50WIP.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-28/index_v26.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index_v26.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-28/index_v26.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-28/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-28/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-27</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-27/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-27/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-22</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-22/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-22/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-22/lme_scanner.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">lme_scanner.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-22/lme_scanner.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-21</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-21/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-21/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-16</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-16/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-16/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-12</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-12/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-12/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-12/market_mayhem_2026-04-12.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">market_mayhem_2026-04-12.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-12/market_mayhem_2026-04-12.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-09</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-09/market_mayhem_2026-04-09.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">market_mayhem_2026-04-09.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-09/market_mayhem_2026-04-09.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-09/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-09/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-08</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-08/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-08/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-04-08/market_mayhem_2026-04-08.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">market_mayhem_2026-04-08.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-08/market_mayhem_2026-04-08.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-06</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-06/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-06/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-05</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-05/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-05/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-02</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-02/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-02/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-04-01</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-04-01/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-04-01/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-03-29</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-03-29/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-03-29/index.html</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-03-27</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-03-27/index.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">index.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-03-27/index.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-03-27/report.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">report.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-03-27/report.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2026-03-24</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2026-03-24/market_mayhem_2026-03-24.html" class="cyber-panel p-4 rounded hover:border-term-cyan/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-cyan bg-term-cyan/10 px-2 py-0.5 rounded border border-term-cyan/20">HTML</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-cyan"><line x1="7" y1="17" x2="17" y2="7"></line><polyline points="7 7 17 7 17 17"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">market_mayhem_2026-03-24.html</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-03-24/market_mayhem_2026-03-24.html</div>
+                    </a>
+
+                    <a href="data/adam_daily/2026-03-24/market_mayhem_2026-03-24.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">market_mayhem_2026-03-24.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2026-03-24/market_mayhem_2026-03-24.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2020-03-16</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2020-03-16/market_mayhem_2020-03-16.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">market_mayhem_2020-03-16.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2020-03-16/market_mayhem_2020-03-16.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2008-09-15</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2008-09-15/market_mayhem_2008-09-15.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">market_mayhem_2008-09-15.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2008-09-15/market_mayhem_2008-09-15.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">2000-03-10</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/2000-03-10/market_mayhem_2000-03-10.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">market_mayhem_2000-03-10.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/2000-03-10/market_mayhem_2000-03-10.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+            <div class="relative mb-12 group">
+                <div class="timeline-dot top-2 group-hover:bg-term-cyan transition-colors"></div>
+
+                <h3 class="text-2xl text-term-cyan font-display mb-4 border-b border-white/10 pb-2 inline-block pr-8">1987-10-23</h3>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+
+                    <a href="data/adam_daily/1987-10-23/market_mayhem_1987-10-23.md" class="cyber-panel p-4 rounded hover:border-term-amber/50 transition-all flex flex-col h-full group/card">
+                        <div class="flex justify-between items-start mb-2">
+                            <span class="text-[10px] font-mono text-term-amber bg-term-amber/10 px-2 py-0.5 rounded border border-term-amber/20">MARKDOWN</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="text-slate-600 group-hover/card:text-term-amber"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path><polyline points="14 2 14 8 20 8"></polyline><line x1="16" y1="13" x2="8" y2="13"></line><line x1="16" y1="17" x2="8" y2="17"></line><polyline points="10 9 9 9 8 9"></polyline></svg>
+                        </div>
+                        <h4 class="text-white text-sm truncate font-mono mb-1">market_mayhem_1987-10-23.md</h4>
+                        <div class="text-[10px] text-slate-500 font-mono mt-auto pt-2 truncate border-t border-white/5">PATH: data/adam_daily/1987-10-23/market_mayhem_1987-10-23.md</div>
+                    </a>
+
+                </div>
+            </div>
+
+        </div>
+    </main>
+
+    <footer class="border-t border-white/10 mt-12 py-6 text-center text-xs font-mono text-slate-500">
+        ADAM SYSTEM ARCHIVE // GENERATED DYNAMICALLY
+    </footer>
+</body>
+</html>

--- a/showcase/index.html
+++ b/showcase/index.html
@@ -207,6 +207,12 @@
             </div>
 
             <div class="grid-container">
+                <div class="module-card" style="border-color: var(--primary-color);">
+                    <h3 class="mono" style="color: var(--primary-color);">ADAM DAILY REPORTS HUB</h3>
+                    <p>A centralized, interactive index of all historical ADAM Daily market reports and data drops</p>
+                    <a href="adam_daily_hub_index.html" style="color: #fff; font-weight: bold; background: rgba(0, 243, 255, 0.2); padding: 5px 10px; border-radius: 4px; display: inline-block; margin-top: 10px;">ENTER HUB &rarr;</a>
+                </div>
+
                 <div class="module-card">
                     <h3 class="mono" style="color: var(--accent-color);">CREDIT & VALUATION</h3>
                     <p>Analyst OS Architect v6.2</p>


### PR DESCRIPTION
This submission resolves the request to build a daily hub under the `showcase/` directory.

### Key Changes
1. **Creation of `adam_daily_hub_index.html`**: A brand new HTML file generated that queries the `showcase/data/adam_daily/` folder, grabbing all historical HTML/MD files and mapping them out chronologically. Designed with a dark mode 'cyberpunk' aesthetic using TailwindCSS for maximum interactivity and visual impact while preserving all content references.
2. **Updates to Main Index (`index.html`)**: Added a visually distinct module card linking to the new daily hub index inside the `showcase/index.html` page to ensure proper end-to-end user navigation.
3. **No Dependency Left Behind**: The temporary generation scripts were used to render the HTML structure and then properly cleaned up so the commit focuses solely on the final HTML artifacts, preventing bloat.

### Verification
- Ran Playwright UI verifications to visually confirm the index rendering and layout. Both the main index card layout and the specific hub timeline looked excellent and structurally sound.
- Code review gave a #Correct# rating. Tests were skipped because this is purely a static HTML presentation update without touching core Python testing logic.

---
*PR created automatically by Jules for task [14435064364603672744](https://jules.google.com/task/14435064364603672744) started by @adamvangrover*