### PR TITLE
⚡ Bolt: Memoize O(N log N) sorting logic in GammaSimulator HFTView

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -182,3 +182,7 @@
 ## 2024-05-31 - [Architecture Scaffold Migration]
 **Learning:** Initial structural scaffolding of modular enterprise agents should start with explicit Protocol/ABC interfaces, ensuring strong separation between System 1 (probabilistic swarms) and deterministic math. Additive extraction from existing files ensures functional equivalence.
 **Action:** Always document the purpose, inputs, and outputs via standardized docstrings to support future multi-agent memory parsing.
+
+## 2024-05-23 - Memoization of sorting logic in HFTView
+**Learning:** Found unnecessary `O(N log N)` re-evaluations inside React component body due to sorting logic. Sorting should be memoized with `useMemo` when working with potentially large lists inside render loops, especially in high-frequency trading view components that might get frequent re-renders from parent state changes.
+**Action:** Always wrap heavy list transformations (like sort, filter over large datasets) inside `useMemo` in React components to avoid burning CPU cycles on unchanged data.

--- a/webapp/src/components/simulation-tools/GammaSimulator.tsx
+++ b/webapp/src/components/simulation-tools/GammaSimulator.tsx
@@ -301,8 +301,12 @@ function InstitutionalView({ nodes }: { nodes: any[] }) {
 }
 
 function HFTView({ nodes }: { nodes: any[] }) {
+  // ⚡ Bolt: Wrapped sortedNodes in useMemo to prevent O(N log N) sorting on every re-render of HFTView.
+  // Expected Impact: Reduces CPU cycle waste when the HFTView re-renders due to other state changes without nodes changing.
   // Sort by liquidity (most distressed first) to simulate an order book looking for targets
-  const sortedNodes = [...nodes].sort((a, b) => a.currentIcr - b.currentIcr).slice(0, 50); // Show top 50
+  const sortedNodes = useMemo(() =>
+    [...nodes].sort((a, b) => a.currentIcr - b.currentIcr).slice(0, 50),
+  [nodes]); // Show top 50
 
   return (
     <div className="flex-1 p-4 flex flex-col h-full overflow-hidden bg-black rounded-lg">


### PR DESCRIPTION
💡 What: Wrapped the `nodes` sorting logic inside `HFTView` component in a `useMemo` hook.
🎯 Why: Previously, the array was being sorted on every single re-render of `HFTView`. Since `HFTView` is part of a complex dashboard, it could re-render frequently (e.g. state changes above). Sorting O(N log N) on every render is inefficient.
📊 Impact: Reduces CPU cycle waste by memoizing the sort operation. It will now only re-run when the `nodes` prop changes.
🔬 Measurement: Can be verified using React DevTools Profiler by observing the render time of `HFTView` with and without `nodes` changing.

---
*PR created automatically by Jules for task [4940310372776483712](https://jules.google.com/task/4940310372776483712) started by @adamvangrover*