### PR TITLE
feat: generate 2026-06-17 daily brief and market data

### DIFF
--- a/showcase/data/adam_daily/2026-06-17/daily_brief.md
+++ b/showcase/data/adam_daily/2026-06-17/daily_brief.md
@@ -1,0 +1,16 @@
+# Adam Daily Brief: June 17, 2026
+
+## Market Overview
+The S&P 500 (^GSPC) is currently trading around 7511.35, while Apple (AAPL) stands at 299.24. The broader market is experiencing a mix of high valuations in specific sectors and uncertainty regarding future monetary policy. A new trend is emerging around the commoditization of AI computing power, indicating a shift in how the tech infrastructure is valued and traded.
+
+## Macro Indicators
+*   **US 10-Year Treasury Yield (^TNX):** 4.428%. Yields remain elevated as the market digests potential changes in the Fed's communication strategy.
+*   **Monetary Policy Uncertainty:** Federal Reserve Chair Warsh is expected to withhold his "dot" from the central bank's interest rate outlook. This unprecedented move adds significant opacity to the Fed's forward guidance, forcing markets to rely more heavily on incoming data rather than official projections.
+
+## Risk Radar
+*   **Private Market Valuations:** Prominent investor Michael Burry has publicly commented on the extreme valuation of SpaceX, suggesting it dwarfs established businesses. While he passed on expensive options to short it, the commentary highlights growing anxiety over "priced for perfection" private market darlings.
+*   **AI Infrastructure Consolidation:** The Trump administration directed Anthropic to limit the reach of its AI model. Prediction markets indicate expectations that access will be restored by July 1. However, this highlights political and regulatory risks associated with foundational AI models.
+
+## Agent Insights
+*   **Risk Officer:** The decision by Fed Chair Warsh to withhold rate projections increases tail risk in fixed income markets. The 10-year yield at 4.428% reflects a 'higher-for-longer' premium. The regulatory intervention in Anthropic also suggests that geopolitical and domestic policy risks are now primary drivers of tech valuations.
+*   **Macro Sentinel:** The concept of "AI compute futures" as a tradeable commodity could dramatically alter data center financing and create new hedging mechanisms. We are monitoring this as a potential structural shift in the energy and technology sectors. Meanwhile, the S&P 500 at 7511 demands strong earnings growth to sustain current multiples, particularly with the 10-year yield remaining stubborn above 4.4%.

--- a/showcase/data/adam_daily/2026-06-17/data.jsonl
+++ b/showcase/data/adam_daily/2026-06-17/data.jsonl
@@ -1,0 +1,5 @@
+{"variable_node": "SPX_Index", "market_level_value": "7511.35", "primary_model_target": "EV", "context_provenance": "Yahoo Finance (1D closing price)"}
+{"variable_node": "US_10Y_Yield", "market_level_value": "4.428%", "primary_model_target": "DCF", "context_provenance": "Yahoo Finance (^TNX 1D data)"}
+{"variable_node": "AAPL_Price", "market_level_value": "299.24", "primary_model_target": "EV", "context_provenance": "Yahoo Finance (1D closing price)"}
+{"variable_node": "SpaceX_Valuation_Risk", "market_level_value": "High", "primary_model_target": "PD", "context_provenance": "CNBC News: Michael Burry considers betting against SpaceX valuation"}
+{"variable_node": "Fed_Rate_Outlook_Uncertainty", "market_level_value": "Elevated", "primary_model_target": "DCF", "context_provenance": "CNBC News: Fed Chair Warsh to withhold 'dot' from rate outlook"}


### PR DESCRIPTION
Generates the Adam Daily Briefing for June 17, 2026. This includes gathering real-world data from Yahoo Finance and CNBC to populate the daily briefing.

- The `daily_brief.md` file contains: Market Overview, Macro Indicators, Risk Radar, and Agent Insights.
- The `data.jsonl` file contains quantitative metrics adhering to the `MarketMayhemLedger` schema, including `primary_model_target` mappings (e.g. `EV`, `DCF`, `PD`) and `context_provenance`.

---
*PR created automatically by Jules for task [10131744118618046096](https://jules.google.com/task/10131744118618046096) started by @adamvangrover*