### PR TITLE
Establish Adam v3.0 Core Kernel and Institutional Evaluation

### DIFF
--- a/adam_v3/kernel/jsonlogic.py
+++ b/adam_v3/kernel/jsonlogic.py
@@ -1,5 +1,8 @@
 import json
+from json_logic import jsonLogic
+
 
 class JsonLogicEvaluator:
+
     def evaluate(self, rule, data):
-        return True
+        return jsonLogic(rule, data)

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,10 +1,17 @@
 import pytest
 from adam_v3.kernel.schema import AgentInput, AgentOutput
 
+
 def test_provenance_trace_optional():
-    output = AgentOutput(status="success", result={"key": "value"})
+    output = AgentOutput(status='success', result={'key': 'value'})
     assert output.provenance_trace is None
 
+
 def test_provenance_trace_set():
-    output = AgentOutput(status="success", result={"key": "value"}, provenance_trace="trace_123")
-    assert output.provenance_trace == "trace_123"
+    output = AgentOutput(status='success', result={'key': 'value'},
+        provenance_trace='trace_123')
+    assert output.provenance_trace == 'trace_123'
+
+
+def check_grounding(output: AgentOutput):
+    assert output.provenance_trace is not None

--- a/tests/unit/test_eval_flywheel.py
+++ b/tests/unit/test_eval_flywheel.py
@@ -1,0 +1,12 @@
+import pytest
+from adam_credit_eval_flywheel import Flywheel
+
+def test_evaluate_state_transition():
+    f = Flywheel()
+    assert f.evaluate_state_transition(0, 1) == 1.0
+    assert f.evaluate_state_transition(1, 0) == 0.0
+
+def test_evaluate_information_gain():
+    f = Flywheel()
+    assert f.evaluate_information_gain({"new_facts_extracted": 5, "tool_calls_used": 2}) == 2.5
+    assert f.evaluate_information_gain({"new_facts_extracted": 0, "tool_calls_used": 0}) == 0.0

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+def test_expected_loss_determinism():
+    pd = 0.05
+    lgd = 0.4
+    ead = 1000000
+    expected_loss = pd * lgd * ead
+    assert expected_loss == pytest.approx(20000.0)


### PR DESCRIPTION
This commit addresses the goal to establish the `adam_v3/kernel` directory and foundational primitives for the Adam Core Kernel:

1. Modifies `tests/test_provenance.py` to add `check_grounding` helper method.
2. Creates `tests/unit/test_eval_flywheel.py` to provide layer 5 and layer 6 Institutional Evaluation Tests.
3. Updates `adam_v3/kernel/jsonlogic.py` to use `jsonLogic` from `json_logic` library.
4. Adds tests for `test_expected_loss_determinism` in `tests/unit/test_kernel.py`.

---
*PR created automatically by Jules for task [3754577531576174805](https://jules.google.com/task/3754577531576174805) started by @adamvangrover*