### PR TITLE
fix: Update pyproject.toml to support modular optional extra environments

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,14 @@ version = "30.1.0"
 description = "Autonomous Financial Analyst System - Unified Kernel"
 authors = ["Adam Van Grover"]
 readme = "README.md"
+packages = [
+    { include = "core" },
+    { include = "services" },
+    { include = "src" }
+]
 
 [tool.poetry.dependencies]
-python = "^3.11" # Adjust to your target Python kernel version
+python = ">=3.11,<3.13" # Adjust to your target Python kernel version
 
 # --- Core Kernel (Always Installed) ---
 pydantic = "2.11.10"
@@ -26,8 +31,8 @@ python-json-logger = "4.0.0"
 
 # --- Web & Async Infrastructure ---
 fastapi = { version = "0.128.0", optional = true }
-uvicorn = { version = "0.34.0", optional = true }
-Flask = { version = "3.1.3", optional = true }
+uvicorn = { version = ">=0.34.0,<1.0.0", optional = true }
+Flask = { version = ">=3.1.3,<4.0.0", optional = true }
 Flask-Cors = { version = "6.0.2", optional = true }
 Flask-SocketIO = { version = "5.6.0", optional = true }
 Flask-JWT-Extended = { version = "4.7.1", optional = true }


### PR DESCRIPTION
Updates `pyproject.toml` with the correct `packages` mapping to fix module discovery, updates version constraints, and adds the requested `Dockerfile.kernel` to support dynamic, multi-stage building utilizing Poetry optional extras.

---
*PR created automatically by Jules for task [4412036605007396304](https://jules.google.com/task/4412036605007396304) started by @adamvangrover*