### PR TITLE
⚡ Bolt: [Optimize Universal Arbitrage Engine walk_book re-evaluation]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -190,3 +190,7 @@
 ## 2026-06-21 - [Optimize Nested Loop Calculations]
 **Learning:** In combinatorial search algorithms like `UniversalArbitrageEngine` which evaluate `O(E^2)` combinations across exchanges, performing inner `O(L)` order book depth walks or O(N) aggregations inside the innermost loop causes massive duplicate effort.
 **Action:** Always hoist independent properties and arrays (like `_walk_book` for varying trade sizes, or `_calculate_micro_price`) outside the nested `i, j` loops, precompute them into O(1) lookup dicts/arrays, and retrieve the pre-calculated values inside the nested loop for an immense speedup.
+
+## 2026-06-23 - [Optimize Combinatorial Book Walking]
+**Learning:** In nested scenarios like the `UniversalArbitrageEngine`, where book walking (`O(L)`) is repeatedly evaluated for identical target volumes, calculating the exact cost recursively creates a measurable bottleneck. Using `tradeable_vol_1 = min(exec_vol_buy_a, exec_vol_sell_b)` and comparing it to the original `target_volume` allows safely reusing the already-calculated cost and revenue, skipping the inner `walk_book` evaluations entirely.
+**Action:** When validating bounds or executing inner algorithmic operations (like L2 book slippage calculations), always check if the bounded output matched the input parameter exactly. If so, directly reuse the original calculation's return value to bypass redundant O(L) or O(N) operations.

--- a/core/agents/specialized/universal_arbitrage_engine.py
+++ b/core/agents/specialized/universal_arbitrage_engine.py
@@ -123,8 +123,13 @@ class UniversalArbitrageEngine(AgentBase):
         tradeable_vol_1 = min(exec_vol_buy_a, exec_vol_sell_b)
 
         # Recalculate exact costs for tradeable volume
-        _, actual_cost_a, _ = self.walk_book(exchange_a_book.asks, tradeable_vol_1)
-        _, actual_rev_b, _ = self.walk_book(exchange_b_book.bids, tradeable_vol_1)
+        # ⚡ Bolt Optimization: Avoid redundant O(L) walk_book calls if tradeable volume is identical to target volume
+        if tradeable_vol_1 == target_volume:
+            actual_cost_a = cost_a
+            actual_rev_b = revenue_b
+        else:
+            _, actual_cost_a, _ = self.walk_book(exchange_a_book.asks, tradeable_vol_1)
+            _, actual_rev_b, _ = self.walk_book(exchange_b_book.bids, tradeable_vol_1)
 
         gross_profit_1 = actual_rev_b - actual_cost_a
 
@@ -134,8 +139,13 @@ class UniversalArbitrageEngine(AgentBase):
 
         tradeable_vol_2 = min(exec_vol_buy_b, exec_vol_sell_a)
 
-        _, actual_cost_b, _ = self.walk_book(exchange_b_book.asks, tradeable_vol_2)
-        _, actual_rev_a, _ = self.walk_book(exchange_a_book.bids, tradeable_vol_2)
+        # ⚡ Bolt Optimization: Reuse precalculated costs if tradeable volume equals target volume
+        if tradeable_vol_2 == target_volume:
+            actual_cost_b = cost_b
+            actual_rev_a = revenue_a
+        else:
+            _, actual_cost_b, _ = self.walk_book(exchange_b_book.asks, tradeable_vol_2)
+            _, actual_rev_a, _ = self.walk_book(exchange_a_book.bids, tradeable_vol_2)
 
         gross_profit_2 = actual_rev_a - actual_cost_b
 


### PR DESCRIPTION
💡 What: Reused the previously computed costs and revenues in `evaluate_arbitrage` when `tradeable_vol` is equal to `target_volume`.
🎯 Why: This avoids an unnecessary O(L) operation inside the most frequently executed logic of `evaluate_arbitrage` where it walks the book again.
📊 Impact: It reduces execution time by potentially 50% for cases where the book has sufficient liquidity.
🔬 Measurement: Observe reduction in loop execution time and duplicate compute effort when running tests.

---
*PR created automatically by Jules for task [7606912478705334994](https://jules.google.com/task/7606912478705334994) started by @adamvangrover*