### PR TITLE
feat: professionalize adam architectural stack via IaC, JsonLogic governance, and provenance tracking

### DIFF
--- a/core/schemas/agent_schema.py
+++ b/core/schemas/agent_schema.py
@@ -1,5 +1,6 @@
 from typing import Dict, Any, List, Optional
 from pydantic import BaseModel, Field
+from src.pdil.models import ProvenanceHeader
 
 class AgentInput(BaseModel):
     """
@@ -17,6 +18,7 @@ class AgentOutput(BaseModel):
     sources: List[str] = Field(default_factory=list, description="List of citations (filenames, URLs).")
     confidence: float = Field(..., ge=0.0, le=1.0, description="Conviction score (0.0 to 1.0).")
     metadata: Dict[str, Any] = Field(default_factory=dict, description="Debug info, token usage, etc.")
+    provenance_trace: ProvenanceHeader = Field(..., description="Immutable provenance trace linking the agent's output to source and logic version.")
 
 class FundamentalReport(BaseModel):
     """

--- a/kubernetes/adam-os-kernel.yaml
+++ b/kubernetes/adam-os-kernel.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: adam-os-kernel
+  labels:
+    app: adam-os
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: adam-os
+  template:
+    metadata:
+      labels:
+        app: adam-os
+    spec:
+      containers:
+      - name: core-engine
+        image: adam-core-engine:latest
+        ports:
+        - containerPort: 50051
+        env:
+        - name: RUST_LOG
+          value: info
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: adam-os-kernel-svc
+spec:
+  selector:
+    app: adam-os
+  ports:
+    - protocol: TCP
+      port: 50051
+      targetPort: 50051

--- a/kubernetes/sidecar-agents.yaml
+++ b/kubernetes/sidecar-agents.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: adam-sidecar-agents
+  labels:
+    app: adam-sidecar
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: adam-sidecar
+  template:
+    metadata:
+      labels:
+        app: adam-sidecar
+    spec:
+      containers:
+      - name: sentinel-nexus-agent
+        image: adam-swarm:latest
+        command: ["python", "core/engine/swarm/entrypoint.py"]
+        ports:
+        - containerPort: 5001
+        env:
+        - name: PYTHONDONTWRITEBYTECODE
+          value: "1"
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        - name: PYTHONPATH
+          value: "/app"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: adam-sidecar-svc
+spec:
+  selector:
+    app: adam-sidecar
+  ports:
+    - protocol: TCP
+      port: 5001
+      targetPort: 5001

--- a/src/governance/gatekeeper.py
+++ b/src/governance/gatekeeper.py
@@ -2,6 +2,7 @@ from src.pdil.models import ProvenanceHeader
 from src.pdil.middleware import (
     GovernanceError,
     SecurityGovernanceGatekeeper,
+    JsonLogicGovernanceGatekeeper,
     DriftIntelligenceLayer,
     ProofOfThoughtLogger,
     MilestoneLogger
@@ -9,6 +10,25 @@ from src.pdil.middleware import (
 
 # Legacy wrapper to not break existing dependencies
 class GovernanceGatekeeper(SecurityGovernanceGatekeeper):
+    def __init__(self, schema=None, rules=None):
+        self._delegate = JsonLogicGovernanceGatekeeper(rules) if rules is not None else None
+        super().__init__(schema or {'type': 'object'})
+
+    def validate_inference(self, inference_output):
+        if self._delegate:
+            return self._delegate.validate_inference(inference_output)
+        return super().validate_inference(inference_output)
+
+    def entry_gate(self, inference_output):
+        if self._delegate:
+            return self._delegate.entry_gate(inference_output)
+        return super().entry_gate(inference_output)
+
+    def exit_gate(self, inference_output):
+        if self._delegate:
+            return self._delegate.exit_gate(inference_output)
+        return super().exit_gate(inference_output)
+
     def detect_and_heal_drift(self, inference_output, historical_hash):
         layer = DriftIntelligenceLayer(self)
         return layer.detect_and_heal_drift(inference_output, historical_hash)

--- a/src/pdil/middleware.py
+++ b/src/pdil/middleware.py
@@ -9,9 +9,69 @@ import jsonschema
 from typing import Dict, Any, Optional
 from src.pdil.models import ProvenanceHeader
 
+from json_logic import jsonLogic
+
 class GovernanceError(Exception):
     """Raised when an inference fails governance validation."""
     pass
+
+class JsonLogicGovernanceGatekeeper:
+    def __init__(self, rules: Dict[str, Any]):
+        """
+        Initializes the gatekeeper with a specific jsonLogic ruleset constraint.
+        Bridges stochastic model outputs with deterministic system inputs using jsonLogic.
+        """
+        self.rules = rules
+
+    def validate_inference(self, inference_output: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Validates LLM probabilistic inferences using jsonLogic.
+        """
+        if "provenance_trace" not in inference_output:
+            raise GovernanceError("Missing 'provenance_trace' containing the ProvenanceHeader.")
+
+        try:
+            # Pydantic validation for the header
+            header = ProvenanceHeader(**inference_output["provenance_trace"])
+        except Exception as e:
+            raise GovernanceError(f"Invalid ProvenanceHeader: {e}")
+
+        # Poison check based on confidence score boundary issues
+        if header.confidence_score < 0.5 or header.confidence_score > 1.0:
+             raise GovernanceError("Poisoned data detected: confidence score out of bounds. Must be >= 0.5")
+
+        # Extract the actual data payload to validate against the jsonLogic rules
+        payload = inference_output.get("data", {})
+
+        if not payload:
+            raise GovernanceError("Missing 'data' payload in inference output.")
+
+        # Strict Provenance Checks: Reproducible Hash Validation
+        payload_json = json.dumps(payload, sort_keys=True, separators=(',', ':')).encode('utf-8')
+        computed_hash = hashlib.sha256(payload_json).hexdigest()
+
+        if header.content_hash != computed_hash:
+            raise GovernanceError(f"Provenance violation: content_hash mismatch. Expected {computed_hash}, got {header.content_hash}")
+
+        # Schema Validation with jsonLogic
+        is_valid = jsonLogic(self.rules, payload)
+        if not is_valid:
+            raise GovernanceError("jsonLogic validation failed: payload does not satisfy rules.")
+
+        return inference_output
+
+    def entry_gate(self, inference_output: Dict[str, Any]) -> Dict[str, Any]:
+        return self.validate_inference(inference_output)
+
+    def exit_gate(self, inference_output: Dict[str, Any]) -> Dict[str, Any]:
+        return self.validate_inference(inference_output)
+
+    async def async_validate_inference(self, inference_output: Dict[str, Any]) -> Dict[str, Any]:
+        return await asyncio.to_thread(self.validate_inference, inference_output)
+
+    async def async_validate_inference_batch(self, inferences: list[Dict[str, Any]]) -> list[Dict[str, Any]]:
+        tasks = [self.async_validate_inference(inference) for inference in inferences]
+        return await asyncio.gather(*tasks)
 
 class SecurityGovernanceGatekeeper:
     def __init__(self, schema: Dict[str, Any]):


### PR DESCRIPTION
## Description of Changes
This pull request transitions the repository from a research-focused prototype to a professional-grade platform by introducing deterministic architectural rigor and modularity.

### 1. Architectural Hardening
- Refactored `SecurityGovernanceGatekeeper` in `src/pdil/middleware.py` to add a `JsonLogicGovernanceGatekeeper` component. This ensures the decoupling of LLM probabilistic reasoning from deterministic risk engine executions using explicit `jsonLogic` evaluations.
- Updated the legacy `GovernanceGatekeeper` wrapper in `src/governance/gatekeeper.py` using the delegate pattern to optionally proxy requests to the new logic evaluation check while retaining backwards compatibility.

### 2. Infrastructure as Code (IaC)
- Scaffolded Kubernetes manifests in a new `kubernetes/` directory:
  - `adam-os-kernel.yaml` deploying the `adam-core-engine` (derived from `core_engine` in `docker-compose.yml` on port `50051`).
  - `sidecar-agents.yaml` deploying the `adam-swarm` sidecar agent mesh configured via the `entrypoint.py` on port `5001`.

### 3. Observability & Provenance
- Hardened `AgentOutput` schema in `core/schemas/agent_schema.py` to mandate the strict inclusion of the `provenance_trace` component (`ProvenanceHeader`). This immutable trace allows for strict hashing back to source data and generation logic.

### 4. Diátaxis Framework Documentation
- Initialized core structured documentation directories (`tutorials`, `how-to`, `explanation`, `reference`) under `docs/` alongside the root-level `SECURITY.md` and `CODE_OF_CONDUCT.md`.

---
*PR created automatically by Jules for task [2386446480631812065](https://jules.google.com/task/2386446480631812065) started by @adamvangrover*