### PR TITLE
feat: Add Quant Prompt Framework (QPF) plugin and schemas

### DIFF
--- a/core/prompting/plugins/qpf_plugin.py
+++ b/core/prompting/plugins/qpf_plugin.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+import re
+from core.prompting.base_prompt_plugin import BasePromptPlugin
+from core.schemas.qpf_schema import QPFInput, QPFOutput
+
+class QPFPlugin(BasePromptPlugin[QPFOutput]):
+    """
+    Quant Prompt Framework (QPF) plugin for high-fidelity quantitative analysis prompts.
+    """
+    def get_input_schema(self) -> type[QPFInput]:
+        return QPFInput
+
+    def get_output_schema(self) -> type[QPFOutput]:
+        return QPFOutput
+
+    def render_messages(self, data: dict) -> list[dict[str, str]]:
+        validated_data = self.get_input_schema()(**data)
+
+        user_content = self.user_engine.render(
+            objective=validated_data.objective,
+            universe=validated_data.universe,
+            data_frequency=validated_data.data_frequency,
+            methodology=validated_data.methodology,
+            deliverable=validated_data.deliverable,
+            risk_metrics=validated_data.risk_metrics,
+            constraints=validated_data.constraints
+        )
+        return [{"role": "user", "content": user_content}]
+
+    def parse_response(self, response: str) -> QPFOutput:
+        return super().parse_response(response)

--- a/core/prompting/registry.py
+++ b/core/prompting/registry.py
@@ -3,6 +3,7 @@ from .base_prompt_plugin import BasePromptPlugin
 from .plugins.financial_truth_plugin import FinancialTruthPlugin
 from .plugins.tree_of_thoughts_plugin import TreeOfThoughtsPlugin
 from .plugins.chain_of_verification_plugin import ChainOfVerificationPlugin
+from .plugins.qpf_plugin import QPFPlugin
 # from .plugins.example_plugin import ExamplePlugin # Example plugin available for reference but not registered by default
 
 
@@ -33,4 +34,5 @@ class PromptRegistry:
 PromptRegistry.register(FinancialTruthPlugin)
 PromptRegistry.register(TreeOfThoughtsPlugin)
 PromptRegistry.register(ChainOfVerificationPlugin)
+PromptRegistry.register(QPFPlugin)
 # PromptRegistry.register(ExamplePlugin)

--- a/core/schemas/__init__.py
+++ b/core/schemas/__init__.py
@@ -5,6 +5,7 @@ from core.schemas.hnasp_integration import IntegratedAgentState, AgentPacket
 from core.schemas.cognitive_state import CognitiveState, StrategicPlan, ThoughtNode
 from core.schemas.observability import AgentTelemetry, Trace, Span, Metric
 from core.schemas.registry import SchemaRegistry
+from core.schemas.qpf_schema import QPFInput, QPFOutput
 
 __all__ = [
     "HNASPState",
@@ -25,4 +26,6 @@ __all__ = [
     "Span",
     "Metric",
     "SchemaRegistry",
+    "QPFInput",
+    "QPFOutput",
 ]

--- a/core/schemas/qpf_schema.py
+++ b/core/schemas/qpf_schema.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, Field
+from typing import Dict, List, Optional, Any
+
+class QPFInput(BaseModel):
+    objective: str = Field(..., description="Objective: e.g., Develop a mean-reversion strategy")
+    universe: str = Field(..., description="Universe: e.g., S&P 500 tech stocks")
+    data_frequency: str = Field(..., description="Data Frequency: e.g., 1-hour bars")
+    methodology: str = Field(..., description="Methodology: e.g., Cointegration and Bollinger Bands")
+    deliverable: str = Field(..., description="Deliverable: e.g., Python code using VectorBT")
+    risk_metrics: str = Field(..., description="Risk Metrics: e.g., Sharpe Ratio and Max Drawdown")
+    constraints: str = Field(..., description="Constraints: e.g., 0.1% slippage and $10k starting capital")
+
+class QPFOutput(BaseModel):
+    python_code: str = Field(..., description="Modular Python code")
+    performance_report: str = Field(..., description="Report with risk metrics")
+    quant_critique: str = Field(..., description="Critique identifying flaws like look-ahead bias")

--- a/prompt_library/AOPL-v1.0/quantitative_analysis/QUANT_PROMPT_FRAMEWORK.md
+++ b/prompt_library/AOPL-v1.0/quantitative_analysis/QUANT_PROMPT_FRAMEWORK.md
@@ -1,0 +1,5 @@
+Act as a Senior Quantitative Researcher. {{ objective }} for {{ universe }} using {{ data_frequency }}. Use {{ methodology }}. Please provide {{ deliverable }} and include {{ risk_metrics }}. Assume {{ constraints }}.
+
+Write the code in a modular format. Include a data-loading function, a signal-generation class, and a performance-reporting module. Use vectorization instead of loops for speed. Strictly forbid the use of `.iterrows()` or manual for-loops for signal calculation. Use NumPy broadcasting or VectorBT's Numba-compiled functions. Ensure all indicators utilize `@numba.njit(parallel=True)`.
+
+Critique this strategy from a quantitative perspective. Identify potential pitfalls like look-ahead bias, overfitting, or sensitivity to execution latency.

--- a/test_qpf.py
+++ b/test_qpf.py
@@ -1,0 +1,41 @@
+import sys
+import os
+
+# Add root to python path to resolve modules
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__))))
+
+from core.schemas.qpf_schema import QPFInput, QPFOutput
+from core.prompting.registry import PromptRegistry
+from core.prompting.plugins.qpf_plugin import QPFPlugin
+
+def main():
+    print("Testing QPFPlugin and Registry")
+    plugin_cls = PromptRegistry.get("QPFPlugin")
+    assert plugin_cls == QPFPlugin, "Plugin not found in registry!"
+
+    print("Success: QPFPlugin found in registry!")
+
+    # Test initialization (basic check to see if we can render)
+    from core.prompting.base_prompt_plugin import PromptMetadata
+    meta = PromptMetadata(prompt_id="test_qpf", author="system")
+    with open("prompt_library/AOPL-v1.0/quantitative_analysis/QUANT_PROMPT_FRAMEWORK.md", "r") as f:
+        template_body = f.read()
+
+    plugin = plugin_cls(metadata=meta, user_template=template_body)
+
+    inputs = {
+        "objective": "Develop a mean-reversion strategy",
+        "universe": "S&P 500 tech stocks",
+        "data_frequency": "1-hour bars",
+        "methodology": "Cointegration and Bollinger Bands",
+        "deliverable": "Python code using VectorBT",
+        "risk_metrics": "Sharpe Ratio and Max Drawdown",
+        "constraints": "0.1% slippage and $10k starting capital",
+    }
+    msgs = plugin.render_messages(inputs)
+    print("Rendered Output:")
+    print(msgs[0]["content"])
+    print("\nTest passed!")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implement the "Quant Prompt Framework" (QPF) as an AOPL prompt plugin with corresponding Pydantic schemas, Jinja2 markdown prompt, and proper registration within the core prompting system. This enables structured, parameter-driven prompts for quantitative analysis.

---
*PR created automatically by Jules for task [2863740645010044577](https://jules.google.com/task/2863740645010044577) started by @adamvangrover*