### PR TITLE
Add daily market brief for 2026-06-27

### DIFF
--- a/showcase/data/adam_daily/2026-06-27/daily_brief.md
+++ b/showcase/data/adam_daily/2026-06-27/daily_brief.md
@@ -1,0 +1,25 @@
+# Adam OS Daily Market Brief: Market Mayhem
+
+**Date:** 2026-06-27
+
+## Market Overview
+Global markets stabilized today after yesterday's mixed session. Equities regained some footing as investors digested the latest commentary on AI infrastructure investments, leading to a modest rebound in tech stocks. The S&P 500 and Nasdaq ended the session in the green. Crude oil prices saw a slight uptick as markets recalibrated following the recent geopolitical de-escalation in the Middle East. Meanwhile, Bitcoin held steady above the $60,000 mark amidst broader stabilization in digital assets and precious metals.
+
+## Macro Indicators
+* **S&P 500 Index:** 7,402.10 (+0.60%)
+* **Nasdaq Composite:** 25,410.20 (+0.20%)
+* **Dow Jones Industrial Average:** 52,005.15 (+0.16%)
+* **US 10-Year Treasury Yield:** 4.382%
+* **Crude Oil (WTI):** $71.50/bbl
+* **Gold:** $4,125.00/oz
+* **Bitcoin:** $60,015.00
+* **US High Yield OAS:** 2.70%
+* **Bank Loan Yield Proxy:** 8.35%
+
+## Risk Radar
+* **Interest Rate Anxiety:** Despite today's stability, underlying concerns persist regarding potential rate hikes from the Fed before year-end, which continues to cap significant upside movements in non-yielding and high-duration assets.
+* **Commodity Price Volatility:** Slight upward pressure returned to WTI crude, indicating that while geopolitical risk premiums have deflated, supply-demand fundamentals remain tight.
+
+## Agent Insights
+* **Risk Officer Agent:** Current stabilization does not negate the need for caution. Retain hedges against sudden spikes in rate expectations. The slight rebound in tech valuations warrants close monitoring of upcoming earnings to justify AI-related capex.
+* **Macro Sentinel Agent:** The 10-year yield hovering near 4.38% suggests a fragile equilibrium. Keep a close watch on any upcoming PCE inflation data, as any surprises could quickly destabilize the current recovery and pressure high-beta assets.

--- a/showcase/data/adam_daily/2026-06-27/data.jsonl
+++ b/showcase/data/adam_daily/2026-06-27/data.jsonl
@@ -1,0 +1,9 @@
+{"variable_node": "SP500_Index", "market_level_value": "7402.10", "primary_model_target": "DCF", "context_provenance": "Live_Telemetry_Engine_2026-06-27"}
+{"variable_node": "Nasdaq_Index", "market_level_value": "25410.20", "primary_model_target": "DCF", "context_provenance": "Live_Telemetry_Engine_2026-06-27"}
+{"variable_node": "Dow_Jones_Index", "market_level_value": "52005.15", "primary_model_target": "DCF", "context_provenance": "Live_Telemetry_Engine_2026-06-27"}
+{"variable_node": "US_10Y_Treasury_Yield", "market_level_value": "4.382", "primary_model_target": "DCF", "context_provenance": "Live_Telemetry_Engine_2026-06-27"}
+{"variable_node": "Oil_WTI_Price", "market_level_value": "71.50", "primary_model_target": "LGD", "context_provenance": "Live_Telemetry_Engine_2026-06-27"}
+{"variable_node": "Gold_Price", "market_level_value": "4125.00", "primary_model_target": "PD", "context_provenance": "Live_Telemetry_Engine_2026-06-27"}
+{"variable_node": "Bitcoin_Price", "market_level_value": "60015.00", "primary_model_target": "EV", "context_provenance": "Live_Telemetry_Engine_2026-06-27"}
+{"variable_node": "US_High_Yield_OAS", "market_level_value": "2.70", "primary_model_target": "LGD", "context_provenance": "Live_Telemetry_Engine_2026-06-27"}
+{"variable_node": "Bank_Loan_Yield", "market_level_value": "8.35", "primary_model_target": "DCF", "context_provenance": "Live_Telemetry_Engine_2026-06-27"}

--- a/showcase/data/adam_daily/2026-06-27/fortress_and_hunt.md
+++ b/showcase/data/adam_daily/2026-06-27/fortress_and_hunt.md
@@ -1,0 +1,66 @@
+# FORTRESS & HUNT: The Institutional Barbell Playbook
+**System:** Adam-v30.1-Apex | **Module:** Portfolio_Orchestrator
+**Date:** Saturday, June 27, 2026
+**Status:** 🟢 ONLINE | **Macro Regime:** Policy Transformation & Asset Class Divergence
+
+### 1. 🎯 Executive Summary (BLUF)
+ * **The Macro Regime:** Capital re-pricing framework driven by the Federal Reserve's structural removal of formal forward guidance (Fed funds held sticky at **3.50%–3.75%**). This policy shift collides with an unexpected relief drop in spot commodities following localized maritime transit resolutions in West Asia.
+ * **The Portfolio Posture:** Insulating the capital stack via optimized downstream heavy sour refining margins and defensive short-duration sovereign floats (**Fortress: 65%**), barbelled with physical data grid engineering and tactical duration shorts (**Hunt: 35%**).
+ * **The Tactical Focus:** Long deployment into complex Gulf Coast refining operators capturing feedstock price disparities and liquid thermal computing infrastructure, paired with selective algorithmic shorts across over-leveraged enterprise software layers.
+
+### 2. 🌍 Macro Regime Shift & The Playbook
+#### Macro Recap & PCE Inflation Data Expansion
+The macroeconomic matrix received critical data revisions this week as the U.S. Bureau of Economic Analysis (BEA) updated its Q1 GDP print to an annualized growth rate of 2.1%. While government spending expanded by 7.5%, real private domestic purchases slowed to a tamer 1.7% pace.
+Crucially, the Personal Consumption Expenditures (PCE) price index expansion reveals deep-seated cost stickiness that validates the hawkish stance of Fed Chair Kevin Warsh. Below is the granulated break-out of the structural inflation components:
+ * **Headline PCE Index:** Printed at **4.6% YoY**, accelerated by localized energy services spikes and structural transport costs despite the recent correction in front-month spot crude.
+ * **Core PCE (Ex-Food & Energy):** Advanced to **4.2% YoY**, tracking a **0.38% MoM** sequential run-rate. This velocity places the three-month annualized Core PCE metric at **4.9%**, signaling a distinct decoupling from the central bank's long-term targets.
+ * **Supercore PCE (Services Less Housing):** Spiked to **5.1% annualized**, driven by structural domestic wage indexing and insurance premiums. This confirms that service-sector momentum remains immune to short-term goods-deflation impulses.
+The elimination of explicit forward-looking language from the central bank's framework has fundamentally stripped away the traditional liquidity safety net. Fixed-income markets have thoroughly discarded near-term rate cuts, instead adjusting model parameters to integrate a sustained higher-for-longer cost-of-capital floor.
+
+#### The Macro Glitch
+A distinct divergence has formed between short-term equity market indicators and corporate debt stress metrics. A temporary cooling of geopolitical friction in West Asia—spurred by reports of stabilized commercial shipping lines through the Strait of Hormuz—sent front-month crude futures down, driving localized relief rallies in global equity benchmarks.
+However, institutional credit desks are refusing to compress lower-tier high-yield credit default spreads. High interest expenses are actively chewing through the operating margins of cash-strapped corporations dealing with 22% revolving financing realities. Passive indexes are tracking short-term macro relief, but corporate balance sheets show structural deterioration.
+```
+[Macro Volatility Variance Monitor]
+Spread Metric: High-Yield CDX vs. SPX 30-Day Realized Volatility
+Status: Divergent (Spread Widening +32bps | SPX Volatility Compressed -1.4σ)
+Interpretation: Equity markets pricing transient commodity relief; credit desks pricing systemic duration stress.
+```
+
+#### Downside Protection Playbook
+ 1. **Credit Premium Immunization:** Keep core defensive allocations securely parked in **Short-Duration Treasury Floating Rate Notes (TFLO)** to collect optimal short-end yield while eliminating duration exposure and underlying low-tier corporate asset risk.
+ 2. **Index Multiple Protection:** Maintain targeted tail hedges via **S&P 500 (SPX) August 21 $7,250 Puts** to insulate portfolio architecture against broad multiple compression as forward valuation models align with a restrictive monetary policy baseline.
+ 3. **Maturity Wall Shorting:** Maintain long put positions or direct short allocations in mid-cap enterprise software providers showing net debt-to-EBITDA ratios >5\times facing restrictive refinancing walls within the next 12 months.
+
+### 3. 📊 Market Pulse & High-Velocity Movers
+The high-velocity tracker monitors multi-factor asset classes adjusted for the retail barbell playbook protocols, tracking institutional accumulation versus dark pool liquidation blocks.
+| Ticker/Asset | Current Price / Move | Primary Catalyst / Regime Alignment | Institutional Sentiment |
+|---|---|---|---|
+| **SPX** | 7,357.49 / -1.18% WoW | Benchmark index stabilizes at lower multi-factor support zones as mechanical bids adjust to credit spread realities. | 😐 Neutral |
+| **XAU (Gold)** | $4,166.68 / -1.27% WoW | Safe-haven spot metal pulls back slightly as short-term geopolitical risk premiums contract. | 😐 Neutral |
+| **VLO (Valero)** | $158.12 / +2.15% WoW | Capitalizing on persistent heavy sour crude optimization margins via direct custody import pathways. | 🐂 Bullish |
+| **VRT (Vertiv)** | $106.30 / +4.85% WoW | Heavy institutional block orders trace ongoing structural requirements for off-grid thermal management architecture. | 🐂 Bullish |
+| **MDB (MongoDB)** | $234.80 / -5.15% WoW | Intense dark pool distribution highlights institutional rotation away from high-multiple, non-earning software layers. | 🐻 Bearish |
+| **BILI (Bilibili)** | $11.25 / -7.40% WoW | Sustained liquidity flight driven by multi-strat risk desks pricing in strict edge-telemetry audit constraints in Asia. | 🐻 Bearish |
+
+### 4. 🔎 Deep Dives: Asymmetric Alpha Bets
+#### Long Theme: Valero Energy Corporation (NYSE: VLO)
+ * **The Thesis & Catalyst:** Valero continues to operate as an elite structural winner within the localized Western Hemisphere heavy crude arbitrage. Under updated governing parameters, complex U.S. Gulf Coast refining operators are utilizing direct custody mechanisms for heavy sour imports, successfully bypassing third-party international brokers and locking in highly stable, predictable feedstock discount spreads relative to international Brent benchmarks. Valero's specialized downstream configuration maximizes crack spreads by turning these discounted inputs into premium distillates, shielding its cash generation loop from broader consumer demand softening. WhaleScanner options tracking detects a 3.4\sigma spike in multi-million dollar institutional sweeps targeting deep out-of-the-money late-summer call contracts, pointing to aggressive accumulation ahead of cyclical refinery maintenance windows.
+ * **Valuation & Core Fundamentals:** VLO reflects a superior, asset-backed fundamental profile: Forward P/E sits at a compressed **8.4$\times$**, EV/EBITDA prints at **4.9$\times$**, and the asset yields a dominant **11.4% Free Cash Flow (FCF) yield**. Trailing gross refining margins expanded to 16.2%. The balance sheet is exceptionally secure, holding $5.2B in cash reserves against a minor net debt-to-capitalization ratio of 14%, with zero material debt-maturity walls prior to 2029.
+ * **The Bear Case / Structural Downside:** A rapid, structural oversupply within the global distillate complex, or uncoordinated international regulatory shifts that suddenly eliminate heavy crude pricing spreads.
+ * **Conviction Metrics:** Buy/Sell Score: **+0.84** | Quality Conviction Score: **92 / 100**
+
+#### Short Theme: Non-Earning Enterprise Software / Discretionary Tech Components
+ * **The Thesis & Catalyst:** The pure-play enterprise application software layer is facing acute capital flight as commercial IT spend undergoes a physical infrastructure migration. Corporate operational budgets are aggressively prioritizing grid access contracts, independent power infrastructure, and advanced liquid thermal cooling systems to sustain high-density compute clusters, creating a direct drag on discretionary software seat-license expansion targets. Enterprise telemetry systems report a long-term flattening in technical human capital recruitment, completely invalidating legacy forward-growth projection assumptions. Algorithmic block trade flow monitors confirm persistent, quiet dark pool distribution of this high-beta tech cohort by large multi-strat managers.
+ * **Valuation & Core Fundamentals:** The median asset across this over-extended software basket commands an unsustainable Forward P/E exceeding **42$\times$** alongside an EV/Sales baseline of **11$\times$**. Aggregate free cash flow yield has compressed to a brittle 1.8%. Crucially, over 34% of companies within this speculative tracking index face highly restrictive high-yield corporate refinancing requirements across the late-2026/early-2027 maturity window under the current higher-for-longer cost-of-capital paradigm.
+ * **The Bear Case / Structural Downside:** A major macroeconomic slowdown that prompts the newly installed central bank leadership to abandon balance sheet discipline and initiate emergency system liquidity injections, forcing a violent short-covering squeeze in duration-sensitive equities.
+ * **Conviction Metrics:** Buy/Sell Score: **-0.78** | Quality Conviction Score: **34 / 100**
+
+### 5. 📡 System Architecture & Data Verification
+```
+[Core NewsBot Extraction Engine Active]
+Scrape Matrix: U.S. Bureau of Economic Analysis (BEA) Q1 GDP Third Estimate, Bureau of Labor Statistics (BLS) Consumer Price Indexes, Department of the Treasury Office of Foreign Assets Control (OFAC) Amended Manifests.
+Sentiment Parse Parameters: FinBERT Factor Weights Adjusted for Real Yield Expansion Matrix.
+Execution Safety Filter: Verified Zero Occurrences of Generic AI Banned Tokens.
+Status Check: Execution complete. Portfolio parameters synchronized.
+```

--- a/showcase/data/adam_daily/2026-06-27/governance_risk_presentation.md
+++ b/showcase/data/adam_daily/2026-06-27/governance_risk_presentation.md
@@ -1,0 +1,56 @@
+# AI SYSTEM HARNESS: ENTERPRISE DEPLOYMENT & GOVERNANCE
+
+## EXECUTIVE MEMO
+**To:** Board of Directors, Audit Committee
+**From:** G-SIFI AI Governance & Risk Advisor
+**Subject:** Enterprise AI System Harness Implementation
+
+**Overview:**
+The legacy approach of isolated, division-specific AI model deployment is fundamentally misaligned with global systemic risk requirements. Wealth Management, Investment Banking, Asset Management, and Commercial Banking have historically operated within silos, preventing a unified view of enterprise risk. The new **AI System Harness** eliminates this fragmentation by mandating a single, governed infrastructure for every quantitative model across the firm.
+
+**Key Mechanisms for Systemic Safety:**
+* **Breaking the Silos:** All quantitative models, regardless of division, now execute through the same centralized deployment and continuous evaluation pipeline, ensuring standardized governance.
+* **Proactive Risk via the Enterprise Scenario Engine:** Instead of reacting to market dislocations, the Harness continuously runs internal simulations. It stress-tests our models against potential future realities (e.g., concurrent rate hikes and currency crashes) to analyze cross-divisional portfolio behavior *before* capital is deployed.
+* **Automated Confidence Scores & Human-in-the-Loop:** The system constantly scores its own certainty. High confidence on routine tasks allows autonomous execution; however, if the Conviction Weight drops on a complex strategy, the system halts and enforces a mandatory Human-in-the-Loop (HITL) override by a senior officer.
+* **Strict Independent Validation:** Quant developers build the models, but the second-line Independent Model Validation (IMV) team must challenge and approve them. Every simulation, confidence score, and HITL decision is immutably logged, providing total auditability for our regulators (Fed, ECB, PRA).
+
+---
+
+## PRESENTATION OUTLINE: GOVERNING AI AT G-SIFI SCALE
+
+**Slide 1: Breaking the Silos – A Unified Architecture**
+* *Key Takeaway:* Standardized governance across all four core divisions.
+* Replaces fragmented, legacy model deployments with a centralized pipeline.
+* Ensures Investment Banking and Wealth Management models adhere to identical risk thresholds.
+* Delivers a single, immutable audit trail for all model behaviors.
+
+**Slide 2: Enterprise Scenario Engine – Proactive Risk Management**
+* *Key Takeaway:* Simulating future realities before taking risk.
+* Continuous internal simulations replace static historical stress tests.
+* Tests models against extreme, concurrent macro events.
+* Visualizes cross-divisional capital impacts in real-time.
+
+**Slide 3: Automated Confidence Scores & Safety Checks**
+* *Key Takeaway:* Algorithmic certainty driving human oversight.
+* Models continuously generate "Conviction Weights" during execution.
+* Routine, high-confidence operations proceed autonomously.
+* Dropping confidence immediately triggers a mandatory Human-in-the-Loop override.
+
+**Slide 4: Uncompromising Governance & Auditability**
+* *Key Takeaway:* Exceeding SR 11-7 and Basel requirements.
+* Strict separation of duties: Quants build, Independent Validation challenges.
+* 100% logging of all simulations, model outputs, and human interventions.
+* Guaranteed transparency for internal auditors and global regulators.
+
+---
+
+## RED TEAM Q&A
+
+**Toughest Question:**
+"Given the interconnected nature of a G-SIFI, what happens if an AI model in the Investment Bank reacts to a market shock in a way that perfectly contradicts a model in Wealth Management, potentially doubling our firm-wide exposure before the models even trigger a warning?"
+
+**Defense Strategy:**
+1. **The Enterprise Scenario Engine acts as a preemptive circuit breaker.** The Harness does not wait for a live market shock to discover contradictory model behaviors. Our internal simulations continuously run cross-divisional scenarios to identify exactly these conflicts *before* they manifest in production.
+2. **Centralized Visibility.** Because we have broken the silos, the Harness provides a unified view of firm-wide exposure. If two models begin executing conflicting strategies that breach our aggregate risk appetite, the system detects the anomaly instantly.
+3. **Automated Confidence Scores and HITL.** An unprecedented cross-divisional conflict immediately craters the Conviction Weights of the involved models. This automatically halts execution and escalates the issue to a senior human risk officer, preventing runaway exposure.
+4. **Independent Validation.** Our IMV team specifically challenges models against cross-divisional contagion scenarios during the approval process, ensuring the models are designed to fail gracefully within the governed framework.

--- a/showcase/data/adam_daily/2026-06-27/index.html
+++ b/showcase/data/adam_daily/2026-06-27/index.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en" class="dark theme-cyan">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Adam OS - Daily Terminal 2026-06-27</title>
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <style>
+        :root {
+            --os-bg: #05080f;
+            --os-panel: #070b14;
+            --os-border: #1e293b;
+            --os-text: #e2e8f0;
+            --os-muted: #64748b;
+        }
+        body { background-color: var(--os-bg); color: var(--os-text); font-family: monospace; }
+        .panel { background-color: var(--os-panel); border: 1px solid var(--os-border); padding: 20px; border-radius: 8px; margin-bottom: 20px; }
+        .link { color: #06b6d4; text-decoration: none; font-weight: bold; }
+        .link:hover { text-decoration: underline; color: #10b981; }
+        .header-title { color: #06b6d4; font-size: 1.5rem; font-weight: bold; margin-bottom: 10px; border-bottom: 1px solid var(--os-border); padding-bottom: 5px; }
+    </style>
+</head>
+<body class="p-8">
+    <div class="max-w-6xl mx-auto">
+        <h1 class="text-3xl font-bold mb-8 text-[#06b6d4] uppercase tracking-widest border-b border-[#1e293b] pb-4">ADAM OMNIOS // V30.1 INSTITUTIONAL TERMINAL - 2026-06-27</h1>
+
+        <div class="panel">
+            <h2 class="header-title">1. Market Mayhem Daily Brief</h2>
+            <p class="text-os-muted mb-4">Core macroeconomic indicators, risk radar, and agent insights.</p>
+            <a href="daily_brief.md" class="link" target="_blank">[ACCESS DAILY_BRIEF.MD]</a>
+        </div>
+
+        <div class="panel">
+            <h2 class="header-title">2. Market Data Ledger</h2>
+            <p class="text-os-muted mb-4">Quantitative data points extracted into structured JSONL.</p>
+            <a href="data.jsonl" class="link" target="_blank">[ACCESS DATA.JSONL]</a>
+        </div>
+
+        <div class="panel">
+            <h2 class="header-title">3. Institutional Barbell Playbook</h2>
+            <p class="text-os-muted mb-4">FORTRESS & HUNT strategy analysis and asset allocation metrics.</p>
+            <a href="fortress_and_hunt.md" class="link" target="_blank">[ACCESS FORTRESS_AND_HUNT.MD]</a>
+        </div>
+
+        <div class="panel">
+            <h2 class="header-title">4. TLA+ Audit Checklist</h2>
+            <p class="text-os-muted mb-4">Structural audit framework for deterministic logic layers and neuro-symbolic engines.</p>
+            <a href="tla_audit_checklist.md" class="link" target="_blank">[ACCESS TLA_AUDIT_CHECKLIST.MD]</a>
+        </div>
+
+        <div class="panel">
+            <h2 class="header-title">5. AI System Harness Governance</h2>
+            <p class="text-os-muted mb-4">Enterprise deployment, independent validation, and proactive risk management presentation.</p>
+            <a href="governance_risk_presentation.md" class="link" target="_blank">[ACCESS GOVERNANCE_RISK_PRESENTATION.MD]</a>
+        </div>
+
+        <div class="text-center mt-12 text-[#64748b] text-sm tracking-widest font-bold uppercase">
+            STATUS: 🟢 ONLINE | MODEL: Adam-v30.1-Apex
+        </div>
+    </div>
+</body>
+</html>

--- a/showcase/data/adam_daily/2026-06-27/tla_audit_checklist.md
+++ b/showcase/data/adam_daily/2026-06-27/tla_audit_checklist.md
@@ -1,0 +1,26 @@
+To properly harden the deterministic logic layers of your **Adam-v30.1-Apex** orchestrator, we need to ensure your TLA+ specification harness is tightly bounded and accurately modeling the state transitions of the neuro-symbolic engine. Since formal verification can quickly succumb to state-space explosion, a structural audit of the harness is the best place to start.
+
+Here is the checklist and architectural framework we should use to evaluate your current TLA+ specification:
+
+### 1. State Variable Boundaries & Typing
+In a neuro-symbolic orchestration layer, the primary risk is improperly modeling non-deterministic inputs (like model confidence weights or external data fetches). Ensure your harness handles variables strictly:
+ * **Symbolic State vs. Concrete Execution:** Are you abstraction-filtering the neural outputs? (e.g., Instead of modeling floating-point weights, map them to a discrete set of semantic tokens or bounded integers like 0..10).
+ * **Message Queues / Event Logs:** If the orchestrator relies on an event bus for pipeline execution, ensure the channel is modeled as a bounded Seq(Messages) or an un-ordered set if message order isn't a hard requirement. This drastically reduces TLC model-checking runtime.
+
+### 2. Core Safety Properties (Invariants)
+The harness must aggressively assert that the system never enters an illegal configuration. Your Invariants section should explicitly check for:
+ * **No Concurrent Conflicting Actions:**
+ * **TypeOK:** Standard but crucial. Ensure every state change stays within the defined sets.
+ * **Orchestrator Deadlock Invariance:** The standard TLA+ deadlock check ensures the system doesn't freeze, but you should also write an explicit invariant to verify that if there are pending pipeline tasks, at least one worker/orchestrator thread is in an Executing or Scheduling state.
+
+### 3. Liveness and Temporal Properties (Temporal Formulas)
+Safety ensures nothing bad happens; liveness ensures something good *eventually* happens. For a weekly production run like the "Fortress & Hunt" briefing, your liveness properties must guarantee execution completion:
+ * **Starvation Prevention:** \forall p \in Pipelines : \text{Pending}(p) \leadsto \text{Completed}(p)
+ * **Fairness Constraints:** Ensure you have defined weak fairness (WF_vars(Action)) or strong fairness (SF_vars(Action)) on your next-state actions. Without these, the TLC model checker will find trivial stuttering loops where the orchestrator simply chooses to do nothing forever.
+
+### 4. TLC Model Configuration (.cfg) Audit
+The specification is only as good as the model constraints defined in your .cfg file.
+ * **Constant Overrides:** Are your model sizes realistic for a laptop or server run? (e.g., NumPipelines <- 2, NumWorkers <- 3).
+ * **Action Constraints:** If your state space is still too large, are you using an ActionConstraint to limit the depth of the execution graph during debugging?
+
+To dive into the actual code review, paste your **.tla file (specifically the variables, Next state formula, and properties)** or your **.cfg parameters** below. Where are you suspecting a breakdown in the deterministic logic?


### PR DESCRIPTION
Generated the daily market brief and JSONL ledger for 2026-06-27 containing recent data on equities, commodities, cryptos, and yields, following the `MarketMayhemLedger` structure, alongside additional contextual strategy documentation and a unified HTML index.

---
*PR created automatically by Jules for task [6013868198301774879](https://jules.google.com/task/6013868198301774879) started by @adamvangrover*