### PR TITLE
Expose PDIL components

### DIFF
--- a/src/governance/__init__.py
+++ b/src/governance/__init__.py
@@ -1,0 +1,3 @@
+from .gatekeeper import GovernanceGatekeeper
+
+__all__ = ["GovernanceGatekeeper"]

--- a/src/governance/gatekeeper.py
+++ b/src/governance/gatekeeper.py
@@ -36,3 +36,5 @@ class GovernanceGatekeeper(SecurityGovernanceGatekeeper):
     def heal_drift(self, inference_output):
         layer = DriftIntelligenceLayer(self)
         return layer.heal_drift(inference_output)
+
+__all__ = ["GovernanceGatekeeper"]

--- a/src/pdil/__init__.py
+++ b/src/pdil/__init__.py
@@ -1,0 +1,35 @@
+from .middleware import (
+    GovernanceError,
+    JsonLogicGovernanceGatekeeper,
+    SecurityGovernanceGatekeeper,
+    DriftIntelligenceLayer,
+    ProofOfThoughtLogger,
+    MilestoneLogger,
+)
+from .optimization import TokenOptimizer
+from .lifecycle import ModelLifecycleManager
+from .system import SystemStateManager
+from .fallbacks import CircuitBreaker, IndependentGatekeeperCheck
+from .models import ProvenanceHeader
+from .flows import ExecutionFlow
+from .primitives import Primitive, DataPrimitive
+from .storage import DriftStorageBackend
+
+__all__ = [
+    "GovernanceError",
+    "JsonLogicGovernanceGatekeeper",
+    "SecurityGovernanceGatekeeper",
+    "DriftIntelligenceLayer",
+    "ProofOfThoughtLogger",
+    "MilestoneLogger",
+    "TokenOptimizer",
+    "ModelLifecycleManager",
+    "SystemStateManager",
+    "CircuitBreaker",
+    "IndependentGatekeeperCheck",
+    "ProvenanceHeader",
+    "ExecutionFlow",
+    "Primitive",
+    "DataPrimitive",
+    "DriftStorageBackend",
+]

--- a/src/pdil/fallbacks.py
+++ b/src/pdil/fallbacks.py
@@ -35,3 +35,5 @@ class IndependentGatekeeperCheck:
             return True
         except GovernanceError:
             return False
+
+__all__ = ["CircuitBreaker", "IndependentGatekeeperCheck"]

--- a/src/pdil/flows.py
+++ b/src/pdil/flows.py
@@ -8,3 +8,5 @@ class ExecutionFlow:
         for step in self.steps:
             result = step(result)
         return result
+
+__all__ = ["ExecutionFlow"]

--- a/src/pdil/lifecycle.py
+++ b/src/pdil/lifecycle.py
@@ -24,3 +24,5 @@ class ModelLifecycleManager:
             model_info["status"] = "DEPRECATED"
             return "DEPRECATED"
         return "ACTIVE"
+
+__all__ = ["ModelLifecycleManager"]

--- a/src/pdil/middleware.py
+++ b/src/pdil/middleware.py
@@ -235,3 +235,12 @@ class MilestoneLogger:
         if not self.milestones:
             return {}
         return sorted(self.milestones, key=lambda m: m["conviction"] / max(m["complexity"], 0.001), reverse=True)[0]
+
+__all__ = [
+    "GovernanceError",
+    "JsonLogicGovernanceGatekeeper",
+    "SecurityGovernanceGatekeeper",
+    "DriftIntelligenceLayer",
+    "ProofOfThoughtLogger",
+    "MilestoneLogger",
+]

--- a/src/pdil/models.py
+++ b/src/pdil/models.py
@@ -12,3 +12,5 @@ class ProvenanceHeader(BaseModel):
     confidence_score: float = Field(..., description="Agent conviction score (0.0 to 1.0)")
     derivation_path: str = Field(..., description="Path indicating how the conclusion was reached (PROV-O: wasDerivedFrom)")
     source_data_object: str = Field(..., description="Reference to the source data object, satisfying W3C PROV-O requirements (PROV-O: hadPrimarySource)")
+
+__all__ = ["ProvenanceHeader"]

--- a/src/pdil/optimization.py
+++ b/src/pdil/optimization.py
@@ -21,3 +21,5 @@ class TokenOptimizer:
         self.usage_stats[model_name]["cost"] += (tokens_used / 1000.0) * cost_per_1k
 
         return self.usage_stats[model_name]
+
+__all__ = ["TokenOptimizer"]

--- a/src/pdil/primitives.py
+++ b/src/pdil/primitives.py
@@ -8,3 +8,5 @@ class DataPrimitive(Primitive):
     """Primitive for handling data inputs."""
     def __init__(self, data: Dict[str, Any]):
         self.data = data
+
+__all__ = ["Primitive", "DataPrimitive"]

--- a/src/pdil/storage.py
+++ b/src/pdil/storage.py
@@ -17,3 +17,5 @@ class DriftStorageBackend:
         self.data[execution_id] = drift_info
         with open(self.storage_path, 'w') as f:
             json.dump(self.data, f)
+
+__all__ = ["DriftStorageBackend"]

--- a/src/pdil/system.py
+++ b/src/pdil/system.py
@@ -17,3 +17,5 @@ class SystemStateManager:
         context = self.global_state.copy()
         context.update(self.layer_states.get(layer_name, {}))
         return context
+
+__all__ = ["SystemStateManager"]


### PR DESCRIPTION
This PR exposes the internal Probabilistic-to-Deterministic Integration Layer (PDIL) architecture components to make them publicly available from their respective packages. It also standardizes the exports via explicit `__all__` definitions to prevent missing dependencies or `ImportError`s when users try to import core systems like `SecurityGovernanceGatekeeper` or `ProofOfThoughtLogger`.

---
*PR created automatically by Jules for task [11204193170458632589](https://jules.google.com/task/11204193170458632589) started by @adamvangrover*