### PR TITLE
feat: Add Adam OS vNext topology manifest

### DIFF
--- a/adam.manifest.json
+++ b/adam.manifest.json
@@ -1,0 +1,44 @@
+{
+  "version": "Adam OS vNext",
+  "architecture": "Multi-Plane Topology",
+  "invariants": {
+    "A": "Decoupled Architecture: LLMs propose, Policy authorizes, Rust executes.",
+    "B": "Governance Boundary: No side effects bypass the policy engine.",
+    "C": "Deterministic Replayability: W3C PROV-O audit trails and context freezing.",
+    "D": "Fail-Closed Security: Unknown intent defaults to denied.",
+    "E": "Execution Isolation: Python Orchestrates, Rust Computes.",
+    "F": "Data Ingestion: System 1 parses chaos to typed schema.",
+    "G": "Graph Representation: DAG for deterministic paths.",
+    "H": "MCP Isolation: Agents only act through defined tools.",
+    "I": "Stateless Swarm: System 1 is ephemeral and non-blocking.",
+    "J": "Agent Consensus: Orchestrator resolves conflict via logic rules."
+  },
+  "execution_domains": [
+    "System 1 (Neural Swarm)",
+    "System 2 (Neuro-Symbolic Graph)",
+    "System 3 (Simulation)"
+  ],
+  "core_paradigms": {
+    "probabilistic_cognition": "LLMs operate solely as orchestrators proposing intent, scenario construction, and anomaly detection.",
+    "deterministic_governance": "All actions are intercepted by a policy engine before state mutation.",
+    "stochastic_simulation": "Adversarial perturbation against bounded financial inputs.",
+    "verifiable_execution": "Native math occurs only inside compiled Rust kernels using isolated deterministic routines."
+  },
+  "governance_substrate": {
+    "policy_isolation": "Actions are vetted through SMT solvers or jsonLogic prior to taking place.",
+    "default_deny": "LLMs request actions, which default to fail-closed postures if untracked."
+  },
+  "context_freezing": {
+    "description": "Analytical parameters are frozen into an immutable Context Object upon creation. The state of this object is hashed and injected as W3C PROV metadata, securing deterministic replayability."
+  },
+  "polyglot_runtime_topology": {
+    "python": "Orchestration, API execution, probabilistic agent reasoning.",
+    "rust": "Deterministic logic. Calculations involving Value at Risk (VaR), stress tests, and Monte Carlo models are performed directly in a compiled Rust kernel bounded by the abi3-py310 standard, releasing the GIL using py.allow_threads() for true concurrency."
+  },
+  "model_context_protocol": {
+    "description": "Agents interact with the world strictly through MCP, guarded by Intent Gates. This secures boundaries against agent goal hijacking and bounds execution."
+  },
+  "w3c_provo_integration": {
+    "description": "Every step in the DAG creates provenance linked data representing the Entity, the Activity, and the Agent. Human overrides are treated solely as Candidate Evidence."
+  }
+}

--- a/evals/architecture/test_architecture.py
+++ b/evals/architecture/test_architecture.py
@@ -1,0 +1,35 @@
+import json
+import pytest
+import os
+
+def test_adam_manifest_exists():
+    assert os.path.exists("adam.manifest.json")
+
+def test_adam_manifest_content():
+    with open("adam.manifest.json") as f:
+        manifest = json.load(f)
+
+    assert manifest["version"] == "Adam OS vNext"
+    assert manifest["architecture"] == "Multi-Plane Topology"
+    assert "core_paradigms" in manifest
+    assert "governance_substrate" in manifest
+    assert "context_freezing" in manifest
+    assert "polyglot_runtime_topology" in manifest
+    assert "model_context_protocol" in manifest
+    assert "w3c_provo_integration" in manifest
+
+def test_invariants_exist():
+    with open("adam.manifest.json") as f:
+        manifest = json.load(f)
+
+    assert "invariants" in manifest
+    invariants = manifest["invariants"]
+    # Verify we have at least invariant A through J
+    for key in ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"]:
+        assert key in invariants
+
+def test_execution_domains_exist():
+    with open("adam.manifest.json") as f:
+        manifest = json.load(f)
+
+    assert "execution_domains" in manifest


### PR DESCRIPTION
This implements the requested Adam OS vNext architectural specification and toolchain configuration inside `adam.manifest.json`, along with an automated evaluator in `evals/architecture/test_architecture.py`.

---
*PR created automatically by Jules for task [4297717347424123325](https://jules.google.com/task/4297717347424123325) started by @adamvangrover*