### PR TITLE
Fix scenario name mismatch in crisis simulation evaluation

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -205,3 +205,7 @@
 ## 2025-02-27 - [Optimize JSON Logic Rule Loading]
 **Learning:** Performing synchronous disk I/O (`open` and `json.load`) repeatedly within calculation or validation methods, such as `AgentOrchestrator._evaluate_preconditions`, creates a severe performance bottleneck during high-frequency rule evaluations across thousands of agent workflows.
 **Action:** Always extract the loading logic into a module-level cached function using `@functools.lru_cache` to bypass disk I/O entirely after the first read, resulting in significantly faster and more stable execution.
+
+## 2026-08-10 - [Test Scenario Name Alignment]
+**Learning:** Hardcoded scenario names in simulation logic (like `scripts/market_mayhem_crisis_sim.py`) must exactly match the strings used in evaluation test scripts (like `evals/eval_crisis_sim.py`). A mismatch can result in silent `None` returns, which subsequently cause runtime errors like `TypeError: 'NoneType' object is not subscriptable` when attempting downstream calculations.
+**Action:** When updating or renaming scenarios or constants in the core simulator, always grep the repository to update corresponding unit tests and evaluations. Conversely, if a test throws a `NoneType` error, verify the key/scenario mapping string first.

--- a/evals/eval_crisis_sim.py
+++ b/evals/eval_crisis_sim.py
@@ -45,7 +45,7 @@ class TestCrisisSimulator(unittest.TestCase):
 
     def test_risk_profile_impact(self):
         """Test that AGGRESSIVE profile has higher volatility (std dev) than CONSERVATIVE."""
-        scenario = "2022_INFLATION"
+        scenario = "2022_INFLATION_SHOCK"
 
         sim_agg = CrisisSimulator(seed="risk_test", risk_profile="AGGRESSIVE")
         res_agg = sim_agg.run_simulation(scenario)


### PR DESCRIPTION
Fix scenario name mismatch in crisis simulation evaluation

- Update the hardcoded scenario name in `evals/eval_crisis_sim.py` from `2022_INFLATION` to `2022_INFLATION_SHOCK` to match the core simulator mapping, fixing a NoneType TypeError during test execution.
- Log the fix in the `.jules/bolt.md` learning journal.

---
*PR created automatically by Jules for task [13768558319106173242](https://jules.google.com/task/13768558319106173242) started by @adamvangrover*