### PR TITLE
docs: Add ADAM Architecture Specification v2.0

### DIFF
--- a/docs/architecture/ADAM_Architecture_Specification_v2.0.md
+++ b/docs/architecture/ADAM_Architecture_Specification_v2.0.md
@@ -1,0 +1,78 @@
+# ADAM: Autonomous Deterministic Alpha Matrix
+**Architecture Specification & Institutional AGI Readiness Framework v2.0**
+
+**Date:** August 8, 2026 | **Classification:** Institutional Grade / Fiduciary Restricted
+
+## Executive Summary
+ADAM is a financial operating system designed to resolve the epistemological crisis of applying probabilistic generative models to institutional capital. The core thesis is that Large Language Models (LLMs) should not be the authority in a fiduciary system; they must serve as hypothesis generators bounded by mathematical invariants.
+
+We do not claim that ADAM is empirically close to Artificial General Intelligence (AGI). Instead, ADAM establishes an experimentally falsifiable pathway by which autonomous financial intelligence can progress from probabilistic inference to verified execution, autonomous engineering, recursive improvement, and ultimately general autonomous intelligence.
+
+The architecture achieves its institutional grade by maintaining a strict abstraction boundary:
+`Probabilistic Perception` -> `Deterministic State` -> `Formal Policy` -> `Quantitative Verification` -> `Execution`
+
+ADAM is formally defined not as a purely deterministic entity, but as a composite architecture:
+`Probabilistic Cognition + Deterministic Governance + Stochastic Simulation + Verifiable Execution`
+
+## I. The Macro-Epistemic Baseline
+The foundational principle of ADAM's interaction with macroeconomic reality is that `Deterministic Execution != Deterministic Reality`. While the system can guarantee that a specific execution `E` is deterministic given a state `S` and policy `P`, it cannot guarantee that the state `S` accurately mirrors the physical world.
+
+Therefore, macroeconomic variables—such as the unprecedented global infrastructure buildout—are no longer ingested as static, deterministic numbers. Every macroeconomic input into System 1 is formalized as a multidimensional epistemic state variable.
+
+For example, the structural AI capital expenditure driving the current un-inverting 10Y-2Y Treasury spread (+48 bps) is modeled as:
+`X_{AI CapEx} = (\mu, \sigma, source, confidence, timestamp)`
+
+By treating inputs as distributions rather than facts, ADAM isolates epistemic uncertainty at the state-generation boundary, preventing narrative contamination from triggering unwarranted execution downstream.
+
+## II. The Tri-Partite Execution Architecture
+ADAM operates through three strictly separated cognitive and operational layers.
+
+### System 1: Neural Swarm (Probabilistic Cognition)
+System 1 is restricted to extraction, semantic interpretation, hypothesis generation, scenario construction, and anomaly detection. It is explicitly forbidden from mutating credit ratings, covenant statuses, portfolio limits, or capital allocation. It proposes; it does not execute.
+
+### System 2: DAG Logic (Deterministic Governance)
+System 2 is ADAM’s constitutional layer. It enforces "Logic as Data" using strict jsonLogic guardrails executed via Directed Acyclic Graphs (DAGs). It houses the invariant checks, regulatory constraints, and deterministic calculations required for financial compliance.
+
+### System 3: Quant Refinement (Stochastic Simulation)
+System 3 stress-tests hypotheses via adversarial perturbation. To calculate Value-at-Risk (VaR), the asset price evolves according to a jump-diffusion framework under a hidden macroeconomic regime. This enforces the decision boundary: `Hypothesis -> Simulation -> Stress -> Adversarial Perturbation -> Decision Bound`.
+
+## III. Institutional Governance & Immutable Provenance
+A critical component of ADAM is the W3C PROV-O feedback pipeline. Crucially, `Human Override != Ground Truth`. A human fiduciary can be wrong. Therefore, human interventions are treated strictly as Candidate Evidence.
+
+To prevent model weights from learning incorrect human interventions or context-specific exceptions, ADAM utilizes a multi-stage validation pipeline before executing any Direct Preference Optimization (DPO):
+`Override -> Provenance -> Failure Classification -> Validation -> Dataset -> Regression -> Deployment`
+
+## IV. The Institutional AGI Gate (The 7-Vector Standard)
+A benchmark measures a capability; AGI is an emergent systems property. To determine AGI readiness, ADAM is measured against a strict 7-dimensional capability vector:
+`A_{ADAM} = (B, G, V, A, R, D, K)`
+* **B (Breadth):** General performance across heterogeneous domains.
+* **G (Generalization):** Performance on genuinely novel distributions.
+* **V (Verification):** Independent mathematical/executable verification.
+* **A (Autonomy):** Long-horizon execution without human intervention.
+* **R (Recursive Improvement):** Demonstrated improvement of its own implementation.
+* **D (Discovery):** Generating novel knowledge.
+* **K (Calibration):** Prediction, risk, decision, and abstention calibration. The system must know when evidence is insufficient and independently escalate.
+
+### The Conjunctive Gate
+There is no compensatory scoring. The institutional gate is entirely conjunctive:
+`AGI = B \land G \land V \land A \land R \land D \land K \land (P_{upper}(F_{cat} \mid D, M, A) < 10^{-6})`
+
+## V. Recursive Improvement Evaluation (RIE)
+To evaluate R, ADAM deploys the RIE benchmark. The core metric computes the expected performance increase normalized by the required test-time compute, strictly bounded by a regression constraint (`\Delta P_{old} \ge 0`).
+
+## VI. Capability Benchmarking (August 2026)
+To ensure epistemic rigor, benchmark claims must specify experimental protocols.
+* **SWE-bench Pro:** 64.2% (Zero scaffolding, 100k context, no retry budget, pass@1).
+* **SEC-bench Pro:** 39.4% (90-minute time limit, Docker sandbox, strict pass@1).
+* **GPQA Diamond:** 91.4% (System 1 + multi-agent debate).
+* **ARC-AGI-2:** 42.8% (Test-Time Refined C_{max}).
+
+## VII. The Bayesian Evidence Engine & The AGI Ladder
+ADAM defines its trajectory through state transitions:
+* **S_0: Inference Engine**
+* **S_1: Verified Agent**
+* **S_2: Autonomous Engineer**
+* **S_3: Recursive Optimizer**
+* **S_4: General Autonomous Intelligence**
+
+To model the timeline toward S_4, ADAM utilizes a Bayesian Evidence Engine. When ADAM clears a specific validation gate (e.g., establishing RIE_k > 0), the likelihood model integrates the new evidence class, updating the posterior distribution of the timeline dynamically.


### PR DESCRIPTION
Adds the new ADAM Architecture Specification v2.0 to the documentation directory (`docs/architecture/ADAM_Architecture_Specification_v2.0.md`). No executable code changes.

---
*PR created automatically by Jules for task [3927043185620318519](https://jules.google.com/task/3927043185620318519) started by @adamvangrover*