### PR TITLE
⚡ Bolt: Add O(1) hash map lookup for EventLedger aggregate retrieval

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -205,3 +205,7 @@
 ## 2025-02-27 - [Optimize JSON Logic Rule Loading]
 **Learning:** Performing synchronous disk I/O (`open` and `json.load`) repeatedly within calculation or validation methods, such as `AgentOrchestrator._evaluate_preconditions`, creates a severe performance bottleneck during high-frequency rule evaluations across thousands of agent workflows.
 **Action:** Always extract the loading logic into a module-level cached function using `@functools.lru_cache` to bypass disk I/O entirely after the first read, resulting in significantly faster and more stable execution.
+
+## 2024-05-30 - [Optimize Aggregate Event Retrieval]
+**Learning:** In CQRS/Event Sourced systems, fetching historical events via a list comprehension on the global ledger (e.g., `[e for e in self._events if e.aggregate_id == ID]`) creates a severe O(N) performance bottleneck per replay request as the ledger grows.
+**Action:** Always maintain an O(1) in-memory index dictionary (`_aggregate_index[aggregate_id] = [event1, event2]`) during event insertion. This allows instant retrieval for aggregate replays without scanning the entire ledger.

--- a/src/core/event_sourcing/ledger.py
+++ b/src/core/event_sourcing/ledger.py
@@ -41,6 +41,7 @@ class EventLedger:
     """
     def __init__(self):
         self._events: List[FinancialEvent] = []
+        self._aggregate_index: Dict[str, List[FinancialEvent]] = {}
 
     def append_event(self, event: FinancialEvent) -> None:
         """Appends a new immutable event to the ledger."""
@@ -57,11 +58,15 @@ class EventLedger:
             raise ValueError(f"Event {event.event_id} failed integrity check. Hash mismatch.")
 
         self._events.append(event)
+        if event.aggregate_id not in self._aggregate_index:
+            self._aggregate_index[event.aggregate_id] = []
+        self._aggregate_index[event.aggregate_id].append(event)
+
         logger.info("event_appended", event_id=event.event_id, aggregate_id=event.aggregate_id, event_type=event.event_type)
 
     def get_events_for_aggregate(self, aggregate_id: str) -> List[FinancialEvent]:
         """Retrieves all events for a specific aggregate, ordered by insertion."""
-        return [e for e in self._events if e.aggregate_id == aggregate_id]
+        return self._aggregate_index.get(aggregate_id, [])
 
     def replay_aggregate(self, aggregate_id: str, reducer: callable, initial_state: Any) -> Any:
         """
@@ -81,3 +86,4 @@ class EventLedger:
     def clear(self) -> None:
         """Clears the ledger. Strictly for testing purposes."""
         self._events = []
+        self._aggregate_index = {}


### PR DESCRIPTION
💡 What: Added an `_aggregate_index` dictionary to `EventLedger` that caches events by `aggregate_id` as they are appended. Modified `get_events_for_aggregate` to use this hash map for retrieval instead of a list comprehension.
🎯 Why: In event-sourced/CQRS systems, replaying an aggregate state requires fetching all its historical events. Fetching these events by iterating over the entire global `_events` list creates a massive `O(N)` bottleneck that severely degrades performance as the system scales and accumulates events.
📊 Impact: Transforms `get_events_for_aggregate` time complexity from `O(N)` to `O(1)`, resulting in near-instantaneous aggregate retrievals and significantly faster aggregate replays, regardless of the global ledger size.
🔬 Measurement: Verified the logic by running `test_ledger.py` utilizing dynamic dependency injection for `pytest`, `structlog`, and `pydantic`. Ensure the `uv.lock` file is untampered.

---
*PR created automatically by Jules for task [517874468031902576](https://jules.google.com/task/517874468031902576) started by @adamvangrover*