### PR TITLE
Add architectural_manifest.yaml

### DIFF
--- a/docs/architecture/architectural_manifest.yaml
+++ b/docs/architecture/architectural_manifest.yaml
@@ -1,0 +1,38 @@
+document_type: Machine Queryable Architecture Manifest
+version: 1.0.0-PROD
+repository: adamvangrover/adam
+
+boundaries:
+  probabilistic_reasoning:
+    language: python
+    directories:
+      - src/agents
+      - src/orchestration
+    restrictions:
+      - no_direct_state_mutation
+      - requires_governance_compilation
+
+  deterministic_execution:
+    language: rust
+    directories:
+      - src/kernel
+      - src/matching_engine
+    restrictions:
+      - no_network_io
+      - pure_functions_only
+      - zero_copy_pycapsule_interface
+
+  governance_layer:
+    language: python
+    directories:
+      - src/pdil
+      - adam_os/kernels/governance
+    policies:
+      - default_deny
+      - jsonLogic_schema_validation
+      - provenance_header_required
+
+  event_transport:
+    technology: nats_jetstream
+    deduplication: exactly_once
+    retention: bounded_stream


### PR DESCRIPTION
This commit adds the `architectural_manifest.yaml` file in `docs/architecture/` with the machine queryable architecture manifest mapping the domain boundaries as requested.

---
*PR created automatically by Jules for task [18060301760286390158](https://jules.google.com/task/18060301760286390158) started by @adamvangrover*