### PR TITLE
⚡ Bolt: Optimize get_by_correlation_id retrieval

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -209,3 +209,6 @@
 ## 2024-05-30 - [Optimize Aggregate Event Retrieval]
 **Learning:** In CQRS/Event Sourced systems, fetching historical events via a list comprehension on the global ledger (e.g., `[e for e in self._events if e.aggregate_id == ID]`) creates a severe O(N) performance bottleneck per replay request as the ledger grows.
 **Action:** Always maintain an O(1) in-memory index dictionary (`_aggregate_index[aggregate_id] = [event1, event2]`) during event insertion. This allows instant retrieval for aggregate replays without scanning the entire ledger.
+## 2024-05-30 - [Optimize Correlation ID Event Retrieval]
+**Learning:** Similar to aggregate replay in CQRS, retrieving events by correlation ID via a list comprehension on the global event store (`[e for e in self._events if e.correlation_id == ID]`) creates a severe O(N) performance bottleneck.
+**Action:** Always maintain an O(1) in-memory index dictionary (`_correlation_index[correlation_id] = [event1, event2]`) during event insertion for instant retrieval.

--- a/core/events/event_store.py
+++ b/core/events/event_store.py
@@ -4,12 +4,16 @@ from core.events.envelope import EventEnvelope
 class EventStore:
     def __init__(self):
         self._events: List[EventEnvelope] = []
+        self._correlation_index = {}  # ⚡ Bolt: O(1) lookup index for correlation IDs
 
     def append(self, event: EventEnvelope):
         self._events.append(event)
+        if event.correlation_id not in self._correlation_index:
+            self._correlation_index[event.correlation_id] = []
+        self._correlation_index[event.correlation_id].append(event)
 
     def get_stream(self) -> List[EventEnvelope]:
         return self._events.copy()
 
     def get_by_correlation_id(self, correlation_id: str) -> List[EventEnvelope]:
-        return [e for e in self._events if e.correlation_id == correlation_id]
+        return list(self._correlation_index.get(correlation_id, []))


### PR DESCRIPTION
💡 What: Introduced a `_correlation_index` dictionary in `EventStore` to map `correlation_id` directly to a list of events. Updated `get_by_correlation_id` to use this dictionary for lookups, returning a safe copy instead of iterating over the entire global event list.
🎯 Why: Fetching historical events by correlation ID previously involved a list comprehension over `self._events`. As the number of events grows, this creates a severe O(N) performance bottleneck for every retrieval, akin to aggregate replay problems in CQRS systems.
📊 Impact: Transforms `get_by_correlation_id` from an O(N) operation to an O(1) dictionary lookup, massively improving retrieval speed in large event streams.
🔬 Measurement: Verified the optimization by successfully running unit tests (`tests/core/event_sourcing/test_ledger.py`) to ensure no behavioral changes. Added journal entry documenting this architectural learning.

---
*PR created automatically by Jules for task [12278796301983230135](https://jules.google.com/task/12278796301983230135) started by @adamvangrover*