### PR TITLE
docs: Expand Swarm Environment Documentation Archive

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,3 +68,13 @@ graph TD
 The system supports dynamic **Environment Rotation**, allowing seamless switching between execution engines (e.g., `LiveMockEngine` vs. `RealTradingEngine`) via configuration. This enables:
 *   **Blue/Green Deployment**: Testing new models in simulation before live rollout.
 *   **Chaos Engineering**: Injecting fault-tolerant engines to test system resilience.
+
+## 5. Swarm Environment Layer
+To support long-running autonomous operations, the architecture includes a modular, portable, and async adversarial-aware swarm environment. As detailed in ADR-0003, this environment leverages fine-tuned in-context learning, deeply managed execution loops, and comprehensive harness telemetry.
+
+The environment utilizes a multidimensional 3x5x7 tiered architecture:
+*   **3-Layer Execution:** Data, Reasoning, Execution.
+*   **5-Layer Governance:** Governance, Models, Agents, Environments, Telemetry.
+*   **7-Layer Integration:** Hardware, OS, Kernel, Swarm, App, Interface, User.
+
+Key capabilities include continuous computation of confidence bands around simulated world model probabilities, active tracking of node connection likelihoods across the semantic and execution graphs, and the population of predictive tail scenarios to forecast high-impact, rare events.

--- a/docs/adr/ADR-0003-portable-async-adversarial-swarm.md
+++ b/docs/adr/ADR-0003-portable-async-adversarial-swarm.md
@@ -1,0 +1,41 @@
+# ADR-0003-Portable-Async-Adversarial-Swarm
+
+## Context
+As the Adam system continues to evolve from short-lived, single-task agents to long-running, autonomous operations (horizon swarms), our environment must adapt. To effectively support these persistent swarms, we need a robust, modular, and portable execution environment that can handle asynchronous operations while maintaining an adversarial-aware posture. These swarms will be heavily reliant on fine-tuned in-context learning, require tightly managed execution loops, and depend on comprehensive harness telemetry for observability.
+
+Furthermore, predicting the outcomes within complex, highly interconnected systems requires an advanced topological approach. We need to construct predictive world models that can calculate confidence bands around simulated probabilities, enabling the identification and preparation for rare but high-impact "tail scenarios."
+
+## Decision
+We will construct a new environment for horizon swarms utilizing a tiered, multidimensional architectural model:
+
+1.  **Three-Layer Execution Stack:**
+    *   **Data Layer:** Ingestion and processing of high-frequency, complex signals from varied environments.
+    *   **Reasoning Layer:** Neuro-symbolic synthesis, leveraging fine-tuned in-context learning for adaptive strategy formulation.
+    *   **Execution Layer:** Asynchronous action implementation and external system interaction.
+
+2.  **Five-Layer Governance and Operations Model:**
+    *   **Governance:** Enforces security, policy compliance, and deterministic guardrails.
+    *   **Models:** The core LLMs/SLMs providing probabilistic inference and world modeling.
+    *   **Agents:** Autonomous entities executing discrete tasks within the swarm.
+    *   **Environments:** Portable, adversarial-aware sandboxes where agents operate and interact.
+    *   **Telemetry:** Comprehensive harness tracking for performance, drift, and state auditing.
+
+3.  **Seven-Layer Systems Integration Architecture:**
+    *   **Hardware:** Bare metal and GPU resources (e.g., cuQuantum).
+    *   **OS:** Foundation infrastructure and virtualization.
+    *   **Kernel:** The AdamOS deterministic core (Rust).
+    *   **Swarm:** Orchestration of the multi-agent hive mind.
+    *   **App:** Domain-specific analytical modules (e.g., Credit Sentinel).
+    *   **Interface:** API and programmatic access (e.g., PDIL gatekeepers).
+    *   **User:** Front-end dashboards, WebXR (Neural Deck), and human-in-the-loop controls.
+
+Within this framework, the environment will continuously compute probabilities for simulated world models, producing explicit confidence bands. It will actively track the likelihood of each node connection forming within our semantic knowledge graph and execution DAG, allowing the system to populate and evaluate predictive tail scenarios based on these probabilistic reasoning paths.
+
+## Status
+Accepted
+
+## Consequences
+- **Enhanced Resilience:** The adversarial-aware nature of the environment ensures swarms can operate safely in hostile or unpredictable data landscapes.
+- **Improved Predictability:** Producing confidence bands and tracking node connection likelihoods will give portfolio managers and operators a quantified measure of risk regarding the system's own strategic projections.
+- **Architectural Complexity:** Implementing the 3x5x7 layer matrix will require strict adherence to interface boundaries, specifically strengthening the PDIL to handle asynchronous telemetry and world model states.
+- **Telemetry Overhead:** The requirement for deep harness telemetry and managed loops will necessitate high-throughput logging and potentially specialized time-series databases to store the generated provenance and topological data.

--- a/docs/adr/ADR-0004-harness-telemetry-and-managed-loops.md
+++ b/docs/adr/ADR-0004-harness-telemetry-and-managed-loops.md
@@ -1,0 +1,25 @@
+# ADR-0004-Harness-Telemetry-and-Managed-Loops
+
+## Context
+As defined in ADR-0003, horizon swarms operate continuously across an asynchronous environment. The lack of standard, discrete request-response boundaries means traditional logging is insufficient. We need to construct a comprehensive observability framework capable of monitoring agentic health, detecting behavioral drift, and capturing semantic reasoning trails over extended periods.
+
+## Decision
+We will implement "Harness Telemetry and Managed Loops," moving away from passive logging to an active, structural monitoring paradigm.
+
+1.  **Managed Execution Loops:**
+    *   Agents will not run unstructured `while True` loops. Instead, they will operate within a "Managed Loop Harness."
+    *   This harness enforces heartbeat intervals, resource quotas, and deterministic checkpointing.
+    *   At the end of each managed cycle, the agent's internal state must be serialized into a W3C PROV-O compliant format before yielding to the orchestrator.
+
+2.  **Harness Telemetry Infrastructure:**
+    *   We will introduce a decentralized telemetry bus. Instead of agents writing directly to a centralized log, they emit structured events (`SwarmPulseEvent`, `ReasoningTraceEvent`, `AnomalyEvent`) onto this bus.
+    *   Telemetry will capture not just the "what" (actions taken) but the "why" (probabilistic distribution of choices considered, attention weights on context, confidence scores).
+    *   This data will be routed to a time-series specialized storage and indexed against the Universal Knowledge Graph to allow for temporal querying of the swarm's thought process.
+
+## Status
+Accepted
+
+## Consequences
+- **Observability:** Provides unprecedented insight into long-running agent behavior, allowing operators to visualize the evolving strategy of the swarm in real-time.
+- **Intervention:** The Managed Loop structure allows the Meta-Orchestrator to pause, rewind, or forcefully adjust an agent's context window if telemetry indicates a deviation from deterministic guardrails.
+- **Performance Overhead:** Emitting rich, structured telemetry continuously will consume compute and bandwidth. Optimization of serialization (e.g., using Rust-backed binary formats for the pulse events) will be required to maintain the latency requirements of the execution layer.

--- a/docs/adr/ADR-0005-predictive-tail-scenarios-in-world-models.md
+++ b/docs/adr/ADR-0005-predictive-tail-scenarios-in-world-models.md
@@ -1,0 +1,27 @@
+# ADR-0005-Predictive-Tail-Scenarios-in-World-Models
+
+## Context
+Standard financial modeling often fails at the extremes, treating anomalous events as statistical outliers rather than structural inevitabilities. The Adam OS requires a methodology to map these complex, high-dimensional uncertainty spaces, specifically predicting "tail scenarios" (low probability, catastrophic or highly lucrative events).
+
+## Decision
+Building upon the Swarm Environment established in ADR-0003, we will implement continuous calculation of predictive tail scenarios using topological world models.
+
+1.  **Confidence Bands around Simulated Probabilities:**
+    *   Instead of point-estimate predictions, our internal LLM/SLM models will output probability distributions for future states (e.g., market moves, credit defaults).
+    *   The environment will continuously calculate confidence bands (e.g., 95%, 99%, 99.9%) around these probabilities, adjusting them in real-time as new data flows through the Data Layer.
+
+2.  **Topological Node Tracking:**
+    *   The system will use the Universal Knowledge Graph to map causal relationships.
+    *   The predictive engine will track the *likelihood of specific node connections forming* in the future (e.g., the likelihood of a connection forming between "Company A Default" and "Supplier B Liquidity Crisis").
+
+3.  **Populating Predictive Tail Scenarios:**
+    *   When the likelihood of anomalous node connections crosses a dynamic threshold, the system automatically spawns a sub-swarm to explore that specific topological path.
+    *   These sub-swarms will populate a registry of predictive tail scenarios, complete with reasoning paths, simulated outcomes, and recommended preemptive actions.
+
+## Status
+Accepted
+
+## Consequences
+- **Proactive Risk Management:** The system shifts from reactive analysis to proactive exploration of edge cases, significantly improving performance in crisis scenarios.
+- **Explainability:** By tracking node connections in a semantic graph, the origin of a tail-risk prediction can be traced back to specific, understandable causal links, rather than being an opaque "black box" output.
+- **Compute Intensity:** Spawning sub-swarms to explore low-probability branches is computationally expensive. This will require dynamic resource allocation, prioritizing the exploration of nodes with the highest potential systemic impact.

--- a/docs/architecture/SWARM_ENVIRONMENT_SPEC.md
+++ b/docs/architecture/SWARM_ENVIRONMENT_SPEC.md
@@ -1,0 +1,43 @@
+# Swarm Environment Specification
+**Version:** 1.0.0
+**Status:** Active Draft
+**Related:** ADR-0003, ADR-0004, ADR-0005
+
+## Overview
+The Swarm Environment is the runtime infrastructure designed for long-running, autonomous "horizon swarms." It provides a modular, portable, asynchronous, and adversarial-aware foundation necessary for maintaining complex agentic workflows over extended temporal horizons.
+
+## The 3x5x7 Architecture Matrix
+
+The environment is structured across three intersecting dimensional models.
+
+### I. The Three-Layer Execution Stack (The Loop)
+This defines the operational cycle of the swarm.
+1.  **Data Layer:** Continuous, high-throughput ingestion of multimodal signals (market ticks, news, unstructured text, visual data).
+2.  **Reasoning Layer:** Neuro-symbolic processing utilizing fine-tuned in-context learning to adapt strategies dynamically based on the current world model.
+3.  **Execution Layer:** Asynchronous action implementation, interacting with external APIs, internal ledgers, and deterministic Rust engines.
+
+### II. The Five-Layer Governance and Operations Model (The Actors)
+This defines the entities and rules within the environment.
+1.  **Governance Layer:** The deterministic gatekeepers (PDIL). Enforces W3C PROV-O compliance, structural guardrails, and hard kill-switches based on confidence thresholds.
+2.  **Models Layer:** The underlying cognitive engines (LLMs/SLMs) utilized for probabilistic inference, scenario generation, and semantic understanding.
+3.  **Agents Layer:** The distinct, autonomous personas operating within the swarm (e.g., Risk Officer, Fundamental Analyst, Nexus Orchestrator).
+4.  **Environments Layer:** The portable sandboxes where agents reside. These are adversarial-aware, designed to detect and mitigate prompt injection, data poisoning, or logical looping.
+5.  **Telemetry Layer:** The harness tracking system (defined in ADR-0004) ensuring total observability through Managed Execution Loops and structural event emitting.
+
+### III. The Seven-Layer Systems Integration Architecture (The Stack)
+This defines the physical and logical software stack.
+1.  **Hardware Layer:** CPU, Memory, and GPU acceleration (e.g., cuQuantum for modeling).
+2.  **OS Layer:** Linux-based virtualization and container orchestration (Kubernetes/Docker).
+3.  **Kernel Layer:** AdamOS (Rust). The deterministic core handling pricing, matching, and system calls.
+4.  **Swarm Layer:** The Meta-Orchestrator and inter-agent communication bus (Python 3.12+, AsyncIO).
+5.  **App Layer:** Domain-specific modules (e.g., Credit Sentinel, Market Mayhem data pipelines).
+6.  **Interface Layer:** API gateways, JSON-RPC endpoints, and WebSockets.
+7.  **User Layer:** Client-side presentation, including the React/Vite Dashboards and WebXR topological visualizers.
+
+## Advanced Capabilities
+
+### Continuous Probabilistic Modeling
+The Swarm Environment utilizes internal World Models to simulate future states. Rather than point estimates, the system continuously computes probability distributions, producing explicit **confidence bands** that update in real-time as the Data Layer processes new information.
+
+### Predictive Tail Scenarios
+Leveraging the Universal Knowledge Graph, the environment actively tracks the likelihood of new edge connections forming between disparate nodes. When probabilistic thresholds are met, the swarm populates **predictive tail scenarios**, mapping out low-probability, high-impact events and tracing the causal reasoning paths required for those events to materialize.

--- a/docs/whitepapers/adam_fine_tuned_quantum_world_model.md
+++ b/docs/whitepapers/adam_fine_tuned_quantum_world_model.md
@@ -47,5 +47,11 @@ The "Odyssey" component serves as the search and response engine. It uses the AV
 *   **Federated Quantum Learning:** Distributing the world model training across secure enclaves to preserve proprietary credit data.
 *   **Real-time Adam Tuning:** continuously updating the annealing schedules based on live market tick data.
 
+### 6. Integration with Swarm Environment
+
+As established in ADR-0003, the AFQWM is directly integrated into the Adam OS long-running Swarm Environment. This operational environment deeply utilizes the AFQWM for continuous probabilistic evaluation:
+*   **Confidence Bands:** The world model's probabilistic density functions provide the statistical foundation for the confidence bands calculated across the swarm's simulations.
+*   **Tail Scenario Generation:** The state-space exploration capabilities of the AFQWM (identifying excited, high-energy states) act as the catalyst for the system to populate and evaluate predictive tail scenarios (ADR-0005) by analyzing complex node connection likelihoods within the Universal Knowledge Graph.
+
 ---
 *Confidential - Internal Use Only*


### PR DESCRIPTION
This PR extensively expands the documentation archive to cover the requirements for long-running horizon swarms. 

It introduces ADR-0004 and ADR-0005 to cover harness telemetry, managed loops, confidence bands, and predictive tail scenarios. It also scaffolds a dedicated architecture specification (`SWARM_ENVIRONMENT_SPEC.md`) detailing the 3-Layer Execution Stack, 5-Layer Governance Model, and 7-Layer Integration Architecture, and ties these concepts into the existing Quantum World Model whitepaper.

---
*PR created automatically by Jules for task [2526849580207761092](https://jules.google.com/task/2526849580207761092) started by @adamvangrover*