### PR TITLE
feat: add static ADAM Ecosystem portal in docs

### DIFF
--- a/docs/api/ecosystem-manifest.json
+++ b/docs/api/ecosystem-manifest.json
@@ -1,0 +1,38 @@
+{
+  "ecosystem": "ADAM vNext",
+  "repository": "https://github.com/adamvangrover/adam",
+  "brands": [
+    {
+      "id": "adam-core",
+      "name": "ADAM Core OS",
+      "focus": "Neuro-Symbolic Orchestration & Deterministic Governance",
+      "url": "/docs/brands/adam-core.html"
+    },
+    {
+      "id": "market-mayhem",
+      "name": "Market Mayhem",
+      "focus": "Macroeconomic Intelligence & Yield Volatility",
+      "url": "/docs/brands/market-mayhem.html"
+    },
+    {
+      "id": "fortress-hunt",
+      "name": "Fortress & Hunt",
+      "focus": "Strategic Capital Allocation & Credit Risk Analytics",
+      "url": "/docs/brands/fortress-hunt.html"
+    },
+    {
+      "id": "exiled-spark",
+      "name": "Exiled Spark",
+      "focus": "Procedural Narrative Engine & Lore Management",
+      "url": "/docs/brands/exiled-spark.html"
+    },
+    {
+      "id": "logic-lab",
+      "name": "Logic Lab",
+      "focus": "Autonomous WebGL Simulations",
+      "url": "/docs/brands/logic-lab.html"
+    }
+  ],
+  "api_version": "1.0",
+  "status": "operational"
+}

--- a/docs/api/schema-registry.json
+++ b/docs/api/schema-registry.json
@@ -1,0 +1,24 @@
+{
+  "registry_version": "3.0.0",
+  "description": "Deterministic Agent Contract Schemas for the ADAM Ecosystem",
+  "schemas": {
+    "FinancialMetrics": {
+      "type": "object",
+      "properties": {
+        "ebitda": { "type": "number", "description": "Earnings Before Interest, Taxes, Depreciation, and Amortization" },
+        "leverage_ratio": { "type": "number", "description": "Total Debt / EBITDA" },
+        "fccr": { "type": "number", "description": "Fixed Charge Coverage Ratio" }
+      },
+      "required": ["ebitda", "leverage_ratio"]
+    },
+    "NarrativeEvent": {
+      "type": "object",
+      "properties": {
+        "entity_id": { "type": "string" },
+        "action": { "type": "string" },
+        "sentiment_shift": { "type": "number", "minimum": -1.0, "maximum": 1.0 }
+      },
+      "required": ["entity_id", "action"]
+    }
+  }
+}

--- a/docs/archive/index.html
+++ b/docs/archive/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Intelligence Vault | ADAM</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel="stylesheet" href="../css/theme.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>
+</head>
+<body class="bg-slate-950 text-slate-200 antialiased min-h-screen flex flex-col">
+
+    <div id="global-header"></div>
+
+    <div class="flex-grow flex overflow-hidden h-[calc(100vh-60px)]">
+        <!-- Sidebar: Search & Filter -->
+        <div class="w-1/3 min-w-[300px] border-r border-slate-800 bg-slate-900/50 flex flex-col">
+            <div class="p-4 border-b border-slate-800">
+                <h2 class="text-xl font-bold font-mono mb-4 text-cyan-400">Intelligence Vault</h2>
+                <div class="relative mb-4">
+                    <i data-lucide="search" class="absolute left-3 top-2.5 w-4 h-4 text-slate-500"></i>
+                    <input type="text" id="archive-search" placeholder="Search artifacts..." class="w-full bg-black/50 border border-slate-700 rounded pl-9 pr-4 py-2 text-sm font-mono focus:outline-none focus:border-cyan-500 transition-colors">
+                </div>
+                <div class="grid grid-cols-2 gap-2 text-xs font-mono">
+                    <select class="archive-filter bg-slate-800 border border-slate-700 rounded p-1.5 text-slate-300" data-filter-type="brand">
+                        <option value="all">All Brands</option>
+                        <option value="adam-core">Core OS</option>
+                        <option value="market-mayhem">Market Mayhem</option>
+                        <option value="fortress-hunt">Fortress & Hunt</option>
+                    </select>
+                    <select class="archive-filter bg-slate-800 border border-slate-700 rounded p-1.5 text-slate-300" data-filter-type="format">
+                        <option value="all">All Formats</option>
+                        <option value="pdf">PDF / Report</option>
+                        <option value="json">JSON Schema</option>
+                        <option value="md">Markdown Memo</option>
+                    </select>
+                </div>
+            </div>
+            <div id="archive-results" class="flex-grow overflow-y-auto p-4 space-y-3">
+                <!-- Populated by JS -->
+            </div>
+        </div>
+
+        <!-- Main Content: Document Reader -->
+        <div class="flex-grow bg-black relative flex flex-col">
+            <div class="glass-header p-4 flex justify-between items-center">
+                <div class="flex items-center gap-3">
+                    <i data-lucide="file-text" class="text-slate-400"></i>
+                    <h3 class="font-bold text-lg">Document Reader</h3>
+                </div>
+                <button class="px-3 py-1 bg-slate-800 hover:bg-slate-700 rounded text-xs font-mono border border-slate-600 flex items-center gap-2">
+                    <i data-lucide="download" class="w-3 h-3"></i> Export Payload
+                </button>
+            </div>
+
+            <div class="flex-grow p-8 overflow-y-auto">
+                <div class="max-w-3xl mx-auto glass-panel p-10 border-slate-800 bg-slate-900/40">
+                    <div class="border-b border-slate-800 pb-6 mb-6">
+                        <h1 class="text-3xl font-bold mb-2">SpaceX S-1 Valuation Simulation</h1>
+                        <div class="text-sm font-mono text-slate-500">Classification: CONFIDENTIAL | Source: Market Mayhem Multi-Agent Swarm</div>
+                    </div>
+
+                    <div class="prose prose-invert prose-slate max-w-none font-sans text-slate-300 leading-relaxed">
+                        <p class="mb-4">This document encapsulates the baseline neuro-symbolic simulation projecting Starlink's revenue trajectory under various macroeconomic stress scenarios...</p>
+
+                        <h3 class="text-xl font-bold text-white mt-8 mb-4">Core Assumptions & Parameters</h3>
+                        <div class="bg-black/50 border border-slate-800 rounded p-4 font-mono text-xs text-amber-400 mb-6">
+                            {"terminal_growth_rate": 0.035, "wacc_base": 0.082, "capex_to_revenue": 0.45}
+                        </div>
+
+                        <p>The mathematical foundation relies on a deterministic DCF model integrated with...</p>
+
+                        <div class="mt-8 p-4 border-l-2 border-cyan-500 bg-cyan-900/10 italic text-slate-400">
+                            "Simulation outputs must be cross-verified against the SEC EDGAR extraction module prior to finalization." - W3C PROV-O Audit Log
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>lucide.createIcons();</script>
+    <script src="../js/query-engine.js"></script>
+    <script src="../js/app.js"></script>
+</body>
+</html>

--- a/docs/brands/adam-core.html
+++ b/docs/brands/adam-core.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ADAM Core OS</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel="stylesheet" href="../css/theme.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>
+</head>
+<body class="bg-slate-950 text-slate-200 antialiased min-h-screen flex flex-col">
+
+    <div id="global-header"></div>
+
+    <main class="flex-grow container mx-auto px-6 py-12">
+        <div class="mb-12 flex flex-col md:flex-row gap-8 items-center border-b border-slate-800 pb-12">
+            <div class="md:w-1/2">
+                <div class="text-cyan-400 mb-4 bg-cyan-900/20 inline-block p-3 rounded-xl border border-cyan-500/30">
+                    <i data-lucide="cpu" class="w-12 h-12"></i>
+                </div>
+                <h1 class="text-4xl md:text-5xl font-bold font-mono text-cyan-50 mb-4">ADAM Core</h1>
+                <p class="text-xl text-slate-400 font-light leading-relaxed">
+                    The deterministic neuro-symbolic engine powering the entire ecosystem.
+                    Enforcing zero-trust workflow orchestration and W3C PROV-O compliance.
+                </p>
+            </div>
+            <div class="md:w-1/2 glass-panel p-6 w-full">
+                <h3 class="font-mono text-sm text-cyan-400 mb-4 uppercase tracking-wider">Architecture Topology</h3>
+                <div class="bg-black/50 rounded p-4 font-mono text-xs text-slate-300 leading-loose border border-slate-800">
+                    <div><span class="text-emerald-400">Governance Plane</span> → [Gatekeeper validation]</div>
+                    <div class="pl-4">↳ <span class="text-amber-400">Schema Registry</span> (FIBO / strict JSON)</div>
+                    <div><span class="text-cyan-400">Execution Kernel</span> → [Rust Deterministic Core]</div>
+                    <div class="pl-4">↳ <span class="text-purple-400">NATS Event Spine</span> (Pub/Sub)</div>
+                    <div><span class="text-rose-400">Cognitive Layer</span> → [LLM Swarm]</div>
+                </div>
+            </div>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div class="glass-panel p-6 border-cyan-900/50">
+                <i data-lucide="shield-check" class="w-8 h-8 text-cyan-400 mb-4"></i>
+                <h3 class="text-lg font-bold mb-2">Deterministic Governance</h3>
+                <p class="text-sm text-slate-400">All unstructured LLM outputs are routed through strict, immutable jsonLogic schemas to prevent hallucination in critical paths.</p>
+            </div>
+            <div class="glass-panel p-6 border-cyan-900/50">
+                <i data-lucide="git-merge" class="w-8 h-8 text-cyan-400 mb-4"></i>
+                <h3 class="text-lg font-bold mb-2">W3C PROV-O Lineage</h3>
+                <p class="text-sm text-slate-400">Every algorithmic decision generates an immutable cryptographic graph trace, ensuring full auditability.</p>
+            </div>
+            <div class="glass-panel p-6 border-cyan-900/50">
+                <i data-lucide="network" class="w-8 h-8 text-cyan-400 mb-4"></i>
+                <h3 class="text-lg font-bold mb-2">Neuro-Symbolic Routing</h3>
+                <p class="text-sm text-slate-400">System 1 (fast neural perception) and System 2 (slow symbolic logic) interact seamlessly via the event spine.</p>
+            </div>
+        </div>
+    </main>
+
+    <script>lucide.createIcons();</script>
+    <script src="../js/app.js"></script>
+</body>
+</html>

--- a/docs/brands/exiled-spark.html
+++ b/docs/brands/exiled-spark.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Exiled Spark</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel="stylesheet" href="../css/theme.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>
+</head>
+<body class="bg-slate-950 text-slate-200 antialiased min-h-screen flex flex-col">
+
+    <div id="global-header"></div>
+
+    <main class="flex-grow container mx-auto px-6 py-12">
+        <div class="mb-12 flex flex-col md:flex-row gap-8 items-center border-b border-slate-800 pb-12">
+            <div class="md:w-1/2">
+                <div class="text-purple-400 mb-4 bg-purple-900/20 inline-block p-3 rounded-xl border border-purple-500/30">
+                    <i data-lucide="sparkles" class="w-12 h-12"></i>
+                </div>
+                <h1 class="text-4xl md:text-5xl font-bold font-mono text-purple-50 mb-4">Exiled Spark</h1>
+                <p class="text-xl text-slate-400 font-light leading-relaxed">
+                    Procedural narrative generation and complex lore state management.
+                    Translating quantitative interactions into qualitative world events.
+                </p>
+            </div>
+            <div class="md:w-1/2 w-full">
+                 <div class="glass-panel p-6 border-purple-900/30">
+                    <div class="flex justify-between items-center mb-4">
+                        <h3 class="font-mono text-sm text-purple-400 uppercase tracking-wider">Dynamic Character Graph</h3>
+                    </div>
+                    <div class="bg-black/50 p-4 rounded border border-slate-800 h-48 flex items-center justify-center font-mono text-xs text-slate-500">
+                        [Knowledge Graph Visualization Component]
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="glass-panel p-8 border-purple-900/50">
+            <h2 class="text-2xl font-bold mb-4">The Lore Engine</h2>
+            <p class="text-slate-400 mb-6 max-w-3xl">
+                Exiled Spark utilizes the ADAM Core graph database to track relationships, factions, and historical events. When the Multi-Agent System resolves a conflict, the narrative engine translates the deterministic outcome into rich, localized text.
+            </p>
+            <div class="flex gap-4">
+                 <button class="px-4 py-2 bg-purple-900/40 hover:bg-purple-800/60 border border-purple-500/50 rounded text-purple-100 font-mono text-sm transition-colors">
+                     Generate Saga Node
+                 </button>
+            </div>
+        </div>
+    </main>
+
+    <script>lucide.createIcons();</script>
+    <script src="../js/app.js"></script>
+</body>
+</html>

--- a/docs/brands/fortress-hunt.html
+++ b/docs/brands/fortress-hunt.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Fortress & Hunt</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <link rel="stylesheet" href="../css/theme.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>
+</head>
+<body class="bg-slate-950 text-slate-200 antialiased min-h-screen flex flex-col">
+
+    <div id="global-header"></div>
+
+    <main class="flex-grow container mx-auto px-6 py-12">
+        <div class="mb-12 flex flex-col md:flex-row gap-8 items-center border-b border-slate-800 pb-12">
+            <div class="md:w-1/2">
+                <div class="text-amber-400 mb-4 bg-amber-900/20 inline-block p-3 rounded-xl border border-amber-500/30">
+                    <i data-lucide="shield" class="w-12 h-12"></i>
+                </div>
+                <h1 class="text-4xl md:text-5xl font-bold font-mono text-amber-50 mb-4">Fortress & Hunt</h1>
+                <p class="text-xl text-slate-400 font-light leading-relaxed">
+                    Institutional-grade capital allocation and risk analytics.
+                    Deep structural modeling of leveraged loans and covenant breaches.
+                </p>
+            </div>
+            <div class="md:w-1/2 w-full">
+                 <div class="glass-panel p-6 border-amber-900/30 h-64">
+                    <div class="flex justify-between items-center mb-4">
+                        <h3 class="font-mono text-sm text-amber-400 uppercase tracking-wider">Credit Risk Stress Monitor</h3>
+                    </div>
+                    <div class="relative h-48 w-full">
+                        <canvas id="risk-chart"></canvas>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div class="glass-panel p-6 border-amber-900/50">
+                <i data-lucide="file-text" class="w-8 h-8 text-amber-400 mb-4"></i>
+                <h3 class="text-lg font-bold mb-2">Automated Underwriting Memos</h3>
+                <p class="text-sm text-slate-400">LLM-driven analysis of SEC filings and private data rooms, extracting structural terms and EBITDA adjustments into structured JSON arrays.</p>
+            </div>
+            <div class="glass-panel p-6 border-amber-900/50">
+                <i data-lucide="alert-triangle" class="w-8 h-8 text-amber-400 mb-4"></i>
+                <h3 class="text-lg font-bold mb-2">Covenant Monitoring</h3>
+                <p class="text-sm text-slate-400">Continuous NLP ingestion of earnings calls and news to flag early-warning triggers for technical defaults on senior secured debt.</p>
+            </div>
+        </div>
+    </main>
+
+    <script>lucide.createIcons();</script>
+    <script src="../js/app.js"></script>
+    <script src="../js/visualizers.js"></script>
+</body>
+</html>

--- a/docs/brands/logic-lab.html
+++ b/docs/brands/logic-lab.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Logic Lab</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel="stylesheet" href="../css/theme.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>
+</head>
+<body class="bg-slate-950 text-slate-200 antialiased min-h-screen flex flex-col">
+
+    <div id="global-header"></div>
+
+    <main class="flex-grow container mx-auto px-6 py-12 flex flex-col items-center justify-center">
+        <div class="text-emerald-400 mb-6 bg-emerald-900/20 inline-block p-4 rounded-full border border-emerald-500/30">
+            <i data-lucide="boxes" class="w-16 h-16"></i>
+        </div>
+        <h1 class="text-4xl md:text-5xl font-bold font-mono text-emerald-50 mb-6 text-center">Logic Lab</h1>
+        <p class="text-xl text-slate-400 font-light leading-relaxed max-w-2xl text-center mb-12">
+            Autonomous puzzle generation and algorithmic WebGL simulations.
+            Testing grounds for combinatorial optimization.
+        </p>
+
+        <div class="w-full max-w-4xl glass-panel p-8 border-emerald-900/50">
+            <div class="flex justify-between items-center mb-6">
+                <h3 class="font-mono text-emerald-400 uppercase tracking-wider">Procedural Canvas Sandbox</h3>
+                <div class="flex gap-2">
+                    <button class="px-3 py-1 bg-slate-800 hover:bg-slate-700 text-xs font-mono rounded border border-slate-600">Re-seed</button>
+                    <button class="px-3 py-1 bg-emerald-900/40 hover:bg-emerald-800/60 text-xs font-mono text-emerald-400 rounded border border-emerald-500/50">Run Gen</button>
+                </div>
+            </div>
+            <div class="aspect-video bg-black/60 rounded border border-slate-800 flex items-center justify-center relative overflow-hidden">
+                <!-- Abstract Logic Pattern Background -->
+                <div class="absolute inset-0 opacity-20" style="background-image: radial-gradient(#10b981 1px, transparent 1px); background-size: 20px 20px;"></div>
+                <div class="z-10 text-slate-500 font-mono text-sm">[WebGL Context Initializing...]</div>
+            </div>
+        </div>
+    </main>
+
+    <script>lucide.createIcons();</script>
+    <script src="../js/app.js"></script>
+</body>
+</html>

--- a/docs/brands/market-mayhem.html
+++ b/docs/brands/market-mayhem.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Market Mayhem</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel="stylesheet" href="../css/theme.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>
+</head>
+<body class="bg-slate-950 text-slate-200 antialiased min-h-screen flex flex-col">
+
+    <div id="global-header"></div>
+
+    <main class="flex-grow container mx-auto px-6 py-12">
+        <div class="mb-12 flex flex-col md:flex-row gap-8 items-center border-b border-slate-800 pb-12">
+            <div class="md:w-1/2">
+                <div class="text-rose-400 mb-4 bg-rose-900/20 inline-block p-3 rounded-xl border border-rose-500/30">
+                    <i data-lucide="activity" class="w-12 h-12"></i>
+                </div>
+                <h1 class="text-4xl md:text-5xl font-bold font-mono text-rose-50 mb-4">Market Mayhem</h1>
+                <p class="text-xl text-slate-400 font-light leading-relaxed">
+                    High-frequency macroeconomic intelligence.
+                    Mapping global yield volatility and sovereign rates sensitivity in real-time.
+                </p>
+            </div>
+            <div class="md:w-1/2 w-full">
+                 <div class="glass-panel p-6 border-rose-900/30">
+                    <div class="flex justify-between items-center mb-4">
+                        <h3 class="font-mono text-sm text-rose-400 uppercase tracking-wider">Live Rates Tracker</h3>
+                        <span class="animate-pulse-glow w-2 h-2 rounded-full bg-rose-500"></span>
+                    </div>
+                    <div class="grid grid-cols-2 gap-4">
+                        <div class="bg-black/40 p-4 rounded border border-slate-800">
+                            <div class="text-xs text-slate-500 font-mono mb-1">US10Y</div>
+                            <div class="text-2xl font-mono text-white">4.28% <span class="text-sm text-emerald-500 ml-2">↑ 0.04</span></div>
+                        </div>
+                        <div class="bg-black/40 p-4 rounded border border-slate-800">
+                            <div class="text-xs text-slate-500 font-mono mb-1">DXY</div>
+                            <div class="text-2xl font-mono text-white">104.2 <span class="text-sm text-rose-500 ml-2">↓ 0.12</span></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Placeholder for Market Data Visualization -->
+        <div class="glass-panel p-6 mb-8 border-slate-800">
+            <h3 class="text-lg font-bold mb-4 font-mono text-slate-300">Volatility Simulation</h3>
+            <div class="h-64 bg-slate-900 rounded border border-slate-800 flex items-center justify-center text-slate-600 font-mono">
+                [Canvas/WebGL Simulation Instance Placeholder]
+            </div>
+        </div>
+
+    </main>
+
+    <script>lucide.createIcons();</script>
+    <script src="../js/app.js"></script>
+</body>
+</html>

--- a/docs/css/theme.css
+++ b/docs/css/theme.css
@@ -1,0 +1,131 @@
+/* ADAM Ecosystem Theme - Cyber-Institutional */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;700&family=Fira+Code:wght@400;600&display=swap');
+
+:root {
+  /* Theme Palette */
+  --bg-base: #090d16;
+  --bg-surface: rgba(15, 23, 42, 0.75);
+  --border-slate: rgba(30, 41, 59, 0.6);
+
+  /* Accents */
+  --accent-cyan: #06b6d4;
+  --accent-emerald: #10b981;
+  --accent-amber: #f59e0b;
+  --accent-crimson: #ef4444;
+  --accent-purple: #a855f7;
+
+  /* Typography */
+  --font-sans: 'Inter', system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+  /* Text */
+  --text-primary: #f8fafc;
+  --text-secondary: #94a3b8;
+  --text-muted: #64748b;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--bg-base);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  background-image:
+    radial-gradient(circle at 15% 50%, rgba(6, 182, 212, 0.05), transparent 25%),
+    radial-gradient(circle at 85% 30%, rgba(16, 185, 129, 0.05), transparent 25%);
+  overflow-x: hidden;
+}
+
+.mono { font-family: var(--font-mono); }
+
+/* Glassmorphism Utilities */
+.glass-panel {
+  background: var(--bg-surface);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid var(--border-slate);
+  border-radius: 0.5rem;
+}
+
+.glass-header {
+  background: rgba(9, 13, 22, 0.85);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid var(--border-slate);
+  position: sticky;
+  top: 0;
+  z-index: 50;
+}
+
+/* Animations */
+@keyframes pulse-glow {
+  0%, 100% { opacity: 1; filter: drop-shadow(0 0 4px var(--accent-cyan)); }
+  50% { opacity: 0.7; filter: drop-shadow(0 0 1px var(--accent-cyan)); }
+}
+
+.animate-pulse-glow {
+  animation: pulse-glow 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+@keyframes slide-up {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-slide-up {
+  animation: slide-up 0.4s ease-out forwards;
+}
+
+/* Custom Scrollbar */
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: var(--bg-base);
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(30, 41, 59, 0.8);
+  border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(51, 65, 85, 0.8);
+}
+
+/* Interactive Elements */
+.interactive-card {
+  transition: all 0.3s ease;
+  cursor: pointer;
+}
+.interactive-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(6, 182, 212, 0.4);
+  box-shadow: 0 4px 20px -2px rgba(6, 182, 212, 0.1);
+}
+
+/* Terminal/Console */
+.terminal-window {
+  background: #0f172a;
+  border: 1px solid var(--border-slate);
+  border-radius: 0.375rem;
+  overflow: hidden;
+}
+.terminal-header {
+  background: #1e293b;
+  padding: 0.5rem 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.terminal-body {
+  padding: 1rem;
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  color: var(--accent-emerald);
+  line-height: 1.5;
+  height: 200px;
+  overflow-y: auto;
+}

--- a/docs/demo/agent-sandbox.html
+++ b/docs/demo/agent-sandbox.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Agent Sandbox Demo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel="stylesheet" href="../css/theme.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>
+</head>
+<body class="bg-slate-950 text-slate-200 antialiased min-h-screen flex flex-col">
+
+    <div id="global-header"></div>
+
+    <main class="flex-grow container mx-auto px-6 py-12 flex flex-col items-center">
+        <div class="w-full max-w-5xl">
+            <div class="mb-8 border-b border-slate-800 pb-6 flex justify-between items-end">
+                <div>
+                    <h1 class="text-3xl font-bold font-mono text-cyan-400 mb-2">Agent Sandbox</h1>
+                    <p class="text-slate-400">Interactive prompt execution and deterministic gatekeeper validation.</p>
+                </div>
+                <div class="flex bg-slate-900 rounded p-1 border border-slate-700">
+                    <button class="px-4 py-1.5 bg-slate-800 text-cyan-400 rounded text-sm font-mono shadow">Human UX</button>
+                    <button class="px-4 py-1.5 text-slate-500 hover:text-slate-300 rounded text-sm font-mono">Raw JSON</button>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+                <!-- Input Panel -->
+                <div class="glass-panel p-6 flex flex-col">
+                    <h3 class="font-bold text-lg mb-4 flex items-center gap-2">
+                        <i data-lucide="edit-3" class="w-5 h-5 text-amber-400"></i> Prompt Construction
+                    </h3>
+
+                    <div class="mb-4">
+                        <label class="block text-xs font-mono text-slate-400 mb-1">Target Bounded Context</label>
+                        <select class="w-full bg-black/50 border border-slate-700 rounded p-2 text-sm font-mono text-slate-200 focus:outline-none focus:border-cyan-500">
+                            <option>Credit Underwriting</option>
+                            <option>Macroeconomic Modeling</option>
+                            <option>Lore Generation (Exiled Spark)</option>
+                        </select>
+                    </div>
+
+                    <div class="mb-4">
+                        <div class="flex justify-between mb-1">
+                            <label class="block text-xs font-mono text-slate-400">Temperature (Determinism)</label>
+                            <span class="text-xs font-mono text-emerald-400">0.0 (Strict)</span>
+                        </div>
+                        <input type="range" min="0" max="100" value="0" class="w-full accent-emerald-500">
+                    </div>
+
+                    <div class="flex-grow mb-4 flex flex-col">
+                        <label class="block text-xs font-mono text-slate-400 mb-1">Execution Payload</label>
+                        <textarea id="sandbox-prompt" class="w-full flex-grow bg-black/50 border border-slate-700 rounded p-3 text-sm font-mono text-emerald-50 focus:outline-none focus:border-cyan-500 resize-none" placeholder="Enter objective (e.g., 'Analyze AAPL Q3 covenant compliance based on SEC filings')">Evaluate TSLA default probability focusing on hardware collateral.</textarea>
+                    </div>
+
+                    <button id="run-sim-btn" class="w-full py-3 bg-cyan-900/50 hover:bg-cyan-800/80 border border-cyan-500/50 rounded font-bold font-mono text-cyan-50 transition-colors flex justify-center items-center gap-2">
+                        <i data-lucide="play" class="w-4 h-4"></i> EXECUTE NEURO-SYMBOLIC GRAPH
+                    </button>
+                </div>
+
+                <!-- Output Terminal -->
+                <div class="flex flex-col h-full">
+                    <div class="terminal-window flex-grow flex flex-col">
+                        <div class="terminal-header">
+                            <span>System 2 Diagnostics</span>
+                            <span class="text-emerald-400 flex items-center gap-1"><i data-lucide="shield-check" class="w-3 h-3"></i> Gatekeeper Active</span>
+                        </div>
+                        <div id="sandbox-terminal" class="terminal-body flex-grow">
+                            <div class="text-slate-500">// System ready. Awaiting prompt execution...</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <script>lucide.createIcons();</script>
+    <script src="../js/query-engine.js"></script>
+    <script src="../js/app.js"></script>
+</body>
+</html>

--- a/docs/demo/risk-modeler.html
+++ b/docs/demo/risk-modeler.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Risk Modeler Demo</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel="stylesheet" href="../css/theme.css">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>
+</head>
+<body class="bg-slate-950 text-slate-200 antialiased min-h-screen flex flex-col">
+
+    <div id="global-header"></div>
+
+    <main class="flex-grow container mx-auto px-6 py-12 flex flex-col items-center justify-center">
+        <div class="text-amber-400 mb-6 bg-amber-900/20 inline-block p-4 rounded-full border border-amber-500/30">
+            <i data-lucide="calculator" class="w-16 h-16"></i>
+        </div>
+        <h1 class="text-4xl md:text-5xl font-bold font-mono text-amber-50 mb-6 text-center">Interactive Risk Modeler</h1>
+        <p class="text-xl text-slate-400 font-light leading-relaxed max-w-2xl text-center mb-12">
+            Client-side Credit Stress-Testing & Cash Flow Simulator. Adjust macroeconomic vectors to observe downstream covenant breach probabilities.
+        </p>
+
+        <div class="w-full max-w-5xl grid grid-cols-1 md:grid-cols-3 gap-6">
+            <div class="glass-panel p-6 flex flex-col gap-4">
+                <h3 class="font-mono text-sm text-amber-400 uppercase tracking-wider mb-2">Macro Vectors</h3>
+
+                <div>
+                    <div class="flex justify-between text-xs font-mono mb-1 text-slate-400">
+                        <label>Base Rate Shock</label>
+                        <span class="text-amber-400">+250 bps</span>
+                    </div>
+                    <input type="range" min="0" max="500" value="250" class="w-full accent-amber-500">
+                </div>
+
+                <div>
+                    <div class="flex justify-between text-xs font-mono mb-1 text-slate-400">
+                        <label>EBITDA Contraction</label>
+                        <span class="text-rose-400">-15%</span>
+                    </div>
+                    <input type="range" min="0" max="50" value="15" class="w-full accent-rose-500">
+                </div>
+
+                <button class="mt-auto w-full py-2 bg-amber-900/40 hover:bg-amber-800/60 border border-amber-500/50 rounded font-mono text-sm text-amber-100 transition-colors">
+                    Recalculate Matrix
+                </button>
+            </div>
+
+            <div class="md:col-span-2 glass-panel p-6 border-amber-900/30">
+                <h3 class="font-mono text-sm text-slate-300 mb-4">Projected Cash Flow vs DSCR Covenant</h3>
+                <div class="h-48 bg-black/50 border border-slate-800 rounded flex items-center justify-center font-mono text-slate-600 text-xs">
+                    [Interactive Chart.js Instance Placeholder - Simulated in Fortress & Hunt View]
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <script>lucide.createIcons();</script>
+    <script src="../js/app.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,1210 +3,173 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Index of /docs</title>
-    <link rel="stylesheet" href="../showcase/css/style.css">
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;700&family=Inter:wght@300;400;600;700&display=swap" rel="stylesheet">
-    <style>
-        .file-list { list-style: none; padding: 0; }
-        .file-item { padding: 8px 12px; border-bottom: 1px solid var(--panel-border); display: flex; align-items: center; justify-content: space-between; transition: background 0.2s; }
-        .file-item:hover { background: rgba(255, 255, 255, 0.05); }
-        .file-icon { margin-right: 10px; width: 20px; text-align: center; display: inline-block; }
-        .file-name { flex-grow: 1; font-family: var(--font-mono); font-size: 0.9rem; color: var(--text-primary); }
-        .file-tag { font-size: 0.7rem; padding: 2px 6px; border-radius: 4px; margin-left: 10px; }
-        .tag-dir { background: rgba(6, 182, 212, 0.1); color: var(--primary-color); border: 1px solid var(--primary-color); }
-        .tag-html { background: rgba(245, 158, 11, 0.1); color: var(--warning-color); border: 1px solid var(--warning-color); }
-        .tag-py { background: rgba(16, 185, 129, 0.1); color: var(--success-color); border: 1px solid var(--success-color); }
-        .readme-container { margin-top: 30px; padding: 20px; background: rgba(0, 0, 0, 0.2); border: 1px solid var(--panel-border); border-radius: 4px; }
-        .readme-title { color: var(--text-secondary); font-size: 0.8rem; text-transform: uppercase; margin-bottom: 10px; letter-spacing: 1px; border-bottom: 1px solid var(--panel-border); padding-bottom: 5px; }
-        .readme-body { font-family: var(--font-mono); font-size: 0.85rem; color: var(--text-muted); white-space: pre-wrap; overflow-x: auto; line-height: 1.5; }
-    </style>
+    <title>ADAM Ecosystem | Unified Financial OS</title>
+
+    <!-- Machine Interfaces -->
+    <link rel="alternate" type="application/json" href="api/ecosystem-manifest.json">
+    <link rel="help" href="llms.txt">
+
+    <!-- Dependencies -->
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://unpkg.com/lucide@latest"></script>
+    <link rel="stylesheet" href="css/theme.css">
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "ADAM Ecosystem",
+      "url": "https://adamvangrover.github.io/adam/",
+      "description": "Unified Financial OS and Neuro-Symbolic Orchestration Platform"
+    }
+    </script>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css" rel="stylesheet" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/prism.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-json.min.js"></script>
 </head>
-<body>
-    <div class="scan-line"></div>
+<body class="bg-slate-950 text-slate-200 antialiased min-h-screen flex flex-col">
 
-    <header class="cyber-header" style="padding: 15px 20px; border-bottom: 1px solid var(--primary-color); background: rgba(5, 11, 20, 0.95); display: flex; justify-content: space-between; align-items: center;">
-        <div>
-            <h1 class="mono" style="margin: 0; font-size: 1.2rem; color: var(--primary-color);">ADAM REPO BROWSER</h1>
-            <div class="mono" style="font-size: 0.8rem; color: var(--text-muted);">PATH: <span style="color: var(--text-primary);">/docs</span></div>
-        </div>
-        <div style="text-align: right;">
-            <div class="cyber-badge badge-cyan">SYSTEM ONLINE</div>
-        </div>
-    </header>
+    <div id="global-header"></div>
 
-    <div style="padding: 20px; max-width: 1200px; margin: 0 auto;">
-        <nav style="margin-bottom: 20px; display: flex; gap: 10px;">
-            <a href="../" class="cyber-btn">&uarr; UP LEVEL</a>
-            <a href="../index.html" class="cyber-btn">ROOT</a>
-            <a href="../showcase/index.html" class="cyber-btn" style="border-color: var(--accent-color); color: var(--accent-color);">MISSION CONTROL</a>
-        </nav>
-
-        <main class="glass-panel" style="padding: 0; overflow: hidden; border-radius: 4px;">
-            <div style="padding: 10px 15px; background: rgba(255,255,255,0.02); border-bottom: 1px solid var(--panel-border); color: var(--text-secondary); font-size: 0.8rem; text-transform: uppercase;">
-                Directory Contents
+    <!-- Hero / Canvas Area -->
+    <div class="relative w-full h-[400px] border-b border-slate-800 bg-black overflow-hidden flex items-center justify-center">
+        <canvas id="network-canvas" class="absolute inset-0 z-0"></canvas>
+        <div class="relative z-10 text-center glass-panel p-8 max-w-2xl mx-4">
+            <h1 class="text-4xl md:text-6xl font-bold font-mono tracking-tight mb-4 text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-emerald-400">
+                ADAM vNext
+            </h1>
+            <p class="text-lg text-slate-300 font-light mb-6">
+                Neuro-Symbolic Orchestration & Deterministic Financial Governance
+            </p>
+            <div class="flex flex-wrap justify-center gap-4">
+                <a href="brands/adam-core.html" class="px-6 py-2 bg-cyan-900/40 border border-cyan-500/50 hover:bg-cyan-800/60 rounded font-mono text-cyan-50 transition-all">Explore Core OS</a>
+                <a href="archive/index.html" class="px-6 py-2 bg-slate-800 border border-slate-600 hover:bg-slate-700 rounded font-mono text-slate-200 transition-all">Intelligence Vault</a>
             </div>
-            <ul class="file-list">
-
-                <li class="file-item">
-                    <a href="api/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">api/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="api_reference/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">api_reference/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="architecture/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">architecture/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="blueprints/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">blueprints/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="case_studies/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">case_studies/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="chatbot-ui/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">chatbot-ui/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="dev/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">dev/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="industry_contacts/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">industry_contacts/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="notebooks/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">notebooks/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="projects/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">projects/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="reviews/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">reviews/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="security/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">security/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="static_site/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">static_site/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="strategies/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">strategies/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="system/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">system/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="technical_specs/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">technical_specs/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="templates/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">templates/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="tutorials/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">tutorials/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="ui_archive_v1/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">ui_archive_v1/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v20.0/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">v20.0/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v21.0/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">v21.0/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v22.0/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">v22.0/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23.0/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">v23.0/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23.5/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">v23.5/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23_manual/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">v23_manual/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v24.0/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">v24.0/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v30_specs/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">v30_specs/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="whitepapers/index.html" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📂</span>
-                        <span class="file-name">whitepapers/</span>
-                        <span class="file-tag tag-dir">DIR</span>
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="01_master_prompt.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">01_master_prompt.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="AGENTS.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">AGENTS.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="AGENTS_KNOWLEDGE_BASE.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">AGENTS_KNOWLEDGE_BASE.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="AGENT_PATTERNS.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">AGENT_PATTERNS.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="ALPHABET_ECOSYSTEM_INTEGRATION.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">ALPHABET_ECOSYSTEM_INTEGRATION.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="APEX_ARCHITECT_GUIDE.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">APEX_ARCHITECT_GUIDE.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="Adam-v19.1-System-Management-and-Optimization-Guide.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">Adam-v19.1-System-Management-and-Optimization-Guide.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="Adam-v19.2-Mapping-Document.txt" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📄</span>
-                        <span class="file-name">Adam-v19.2-Mapping-Document.txt</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="Adam-v19.2-system-prompt.txt" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📄</span>
-                        <span class="file-name">Adam-v19.2-system-prompt.txt</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="Adam-v21.0-Mapping-Document.txt" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📄</span>
-                        <span class="file-name">Adam-v21.0-Mapping-Document.txt</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="Adam-v21.0-system-prompt.txt" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📄</span>
-                        <span class="file-name">Adam-v21.0-system-prompt.txt</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="Conceptual-CACM-ADK-System-Architecture-(Mermaid-Syntax).md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">Conceptual-CACM-ADK-System-Architecture-(Mermaid-Syntax).md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="DEVELOPMENT_BEST_PRACTICES.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">DEVELOPMENT_BEST_PRACTICES.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="DISCLAIMERS_AND_ASSUMPTIONS.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">DISCLAIMERS_AND_ASSUMPTIONS.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="DYNAMIC_DATA_GUIDE.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">DYNAMIC_DATA_GUIDE.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="FUTURE_ROADMAP_v24.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">FUTURE_ROADMAP_v24.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="GOLD_STANDARD_PIPELINE.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">GOLD_STANDARD_PIPELINE.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="GOVERNANCE.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">GOVERNANCE.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="JPM_AI_INFRASTRUCTURE_DEV_NOTES.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">JPM_AI_INFRASTRUCTURE_DEV_NOTES.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="MAINTENANCE_LOG.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">MAINTENANCE_LOG.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="META_AGENTS_DEVELOPMENT.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">META_AGENTS_DEVELOPMENT.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="MIGRATION_GUIDE_v23.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">MIGRATION_GUIDE_v23.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="MODULAR_ARCHITECTURE.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">MODULAR_ARCHITECTURE.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="PROJECT_OMEGA_v25_PARADIGM.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">PROJECT_OMEGA_v25_PARADIGM.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="REPO_ASSESSMENT_AND_PLAN.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">REPO_ASSESSMENT_AND_PLAN.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="REQUIREMENTS.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">REQUIREMENTS.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="SCENARIO_AUTHORING.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">SCENARIO_AUTHORING.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="SECURITY.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">SECURITY.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="SETUP_GUIDE.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">SETUP_GUIDE.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="SHOWCASE_GUIDE.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">SHOWCASE_GUIDE.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="SWARM_ARCHITECTURE.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">SWARM_ARCHITECTURE.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="SWARM_EVOLUTION_LOG.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">SWARM_EVOLUTION_LOG.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="SWARM_REPAIR_GUIDE.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">SWARM_REPAIR_GUIDE.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="SYSTEM_MANIFEST.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">SYSTEM_MANIFEST.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="SYSTEM_OVERVIEW.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">SYSTEM_OVERVIEW.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="TUTORIAL_AGENTS.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">TUTORIAL_AGENTS.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="adam_github_summary.json" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">{}</span>
-                        <span class="file-name">adam_github_summary.json</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="adam_project_simulation.json" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">{}</span>
-                        <span class="file-name">adam_project_simulation.json</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="adam_v15.4_guide.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">adam_v15.4_guide.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="adam_v22_technical_migration_plan.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">adam_v22_technical_migration_plan.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="adam_v24_roadmap.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">adam_v24_roadmap.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="agent_development.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">agent_development.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="agent_skills.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">agent_skills.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="agent_skills_registry.json" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">{}</span>
-                        <span class="file-name">agent_skills_registry.json</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="api.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">api.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="api_docs.yaml" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📄</span>
-                        <span class="file-name">api_docs.yaml</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="architecture.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">architecture.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="architecture_v19.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">architecture_v19.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="async_swarm_workflow.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">async_swarm_workflow.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="automated_agent_improvement.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">automated_agent_improvement.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="autonomy_guide.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">autonomy_guide.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="copilot_quest_blueprint.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">copilot_quest_blueprint.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="counterfactual_reasoning.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">counterfactual_reasoning.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="credit_sentry_architecture.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">credit_sentry_architecture.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="custom_builds.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">custom_builds.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="data_provenance.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">data_provenance.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="demo_v23_refactor.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">demo_v23_refactor.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="deployment.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">deployment.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="deployment_checklist.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">deployment_checklist.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="development_notes.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">development_notes.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="dynamic_workflows.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">dynamic_workflows.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="echo_agent_specification.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">echo_agent_specification.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="federated-learning-model-setup-guide.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">federated-learning-model-setup-guide.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="financial_suite_usage.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">financial_suite_usage.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="future_state_roadmap.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">future_state_roadmap.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="gemini_integration_guide.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">gemini_integration_guide.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="getting_started.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">getting_started.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="github_pages_deployment.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">github_pages_deployment.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="glossary.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">glossary.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="google_integration_guide.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">google_integration_guide.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="hybrid_forecasting.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">hybrid_forecasting.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="integration_guide.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">integration_guide.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="json_rpc_prompting_guide.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">json_rpc_prompting_guide.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="knowledge_graph_optimization.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">knowledge_graph_optimization.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="learnings.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">learnings.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="llm_readability_audit.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">llm_readability_audit.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="machine_capabilities.json" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">{}</span>
-                        <span class="file-name">machine_capabilities.json</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="machine_manifest.json" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">{}</span>
-                        <span class="file-name">machine_manifest.json</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="modernization_report.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">modernization_report.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="odyssey_architecture.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">odyssey_architecture.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="odyssey_knowledge_graph_upgrade.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">odyssey_knowledge_graph_upgrade.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="outstanding_errors.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">outstanding_errors.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="prompt_authoring.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">prompt_authoring.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="red_teaming.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">red_teaming.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="setup.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">setup.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="setup_guide.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">setup_guide.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="simulation.ipynb" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📄</span>
-                        <span class="file-name">simulation.ipynb</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="technical_docs_v23_5.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">technical_docs_v23_5.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="the_protocol_paradox.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">the_protocol_paradox.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="troubleshooting.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">troubleshooting.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="tutorials.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">tutorials.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="ui_overview.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">ui_overview.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="user_guide.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">user_guide.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v22_architecture_integration.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v22_architecture_integration.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v22_quantum_pipeline.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v22_quantum_pipeline.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23.5_MARKET_MAYHEM_UPDATE.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v23.5_MARKET_MAYHEM_UPDATE.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23.5_MIGRATION_PLAN.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v23.5_MIGRATION_PLAN.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23.5_showcase_updates.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v23.5_showcase_updates.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23_5_apex_engine.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v23_5_apex_engine.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23_5_deep_dive_manual.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v23_5_deep_dive_manual.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23_5_remediation_plan.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v23_5_remediation_plan.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23_agent_roadmap.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v23_agent_roadmap.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23_architect_learnings.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v23_architect_learnings.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23_architecture_vision.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v23_architecture_vision.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v23_snc_graph.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v23_snc_graph.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v24_MIGRATION_PLAN.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v24_MIGRATION_PLAN.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v24_architecture_blueprint.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v24_architecture_blueprint.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v24_architecture_preview.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v24_architecture_preview.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v24_remediation_plan.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v24_remediation_plan.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v25_architectural_blueprint.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v25_architectural_blueprint.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v25_implementation_status.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v25_implementation_status.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="v25_strategic_divergence_roadmap.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">v25_strategic_divergence_roadmap.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="verify_agent_registry.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">verify_agent_registry.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="walkthrough.ipynb" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📄</span>
-                        <span class="file-name">walkthrough.ipynb</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="webapp.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">webapp.md</span>
-
-                    </a>
-                </li>
-
-                <li class="file-item">
-                    <a href="xai.md" style="display: flex; align-items: center; width: 100%; color: inherit; text-decoration: none;">
-                        <span class="file-icon">📝</span>
-                        <span class="file-name">xai.md</span>
-
-                    </a>
-                </li>
-
-            </ul>
-        </main>
-
-
+        </div>
     </div>
 
-    <footer style="margin-top: 50px; text-align: center; color: var(--text-muted); font-size: 0.8rem; padding-bottom: 20px;">
-        ADAM AUTO-GENERATED SHOWCASE | REF: docs
+    <!-- Telemetry Bar -->
+    <div class="w-full bg-slate-900 border-b border-slate-800 py-2 px-6 flex justify-between items-center text-xs font-mono">
+        <div class="flex gap-6">
+            <span class="text-slate-400">SYSTEM: <span class="text-emerald-400">ONLINE</span></span>
+            <span class="text-slate-400 hidden sm:inline">GOVERNANCE: <span class="text-emerald-400">ENFORCED</span></span>
+        </div>
+        <div class="flex gap-6">
+            <span class="text-slate-400">LATENCY: <span id="tel-latency" class="text-cyan-400">12ms</span></span>
+            <span class="text-slate-400">AGENTS: <span id="tel-agents" class="text-amber-400">142</span></span>
+        </div>
+    </div>
+
+    <!-- Main Content / Matrix Grid -->
+    <main class="flex-grow container mx-auto px-6 py-12">
+        <div class="mb-8 flex justify-between items-end">
+            <div>
+                <h2 class="text-2xl font-semibold mb-2">Ecosystem Matrix</h2>
+                <p class="text-slate-400 text-sm">Select an operational domain</p>
+            </div>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
+
+            <!-- ADAM Core -->
+            <a href="brands/adam-core.html" class="interactive-card glass-panel p-6 flex flex-col h-full border-cyan-900/50">
+                <div class="text-cyan-400 mb-4">
+                    <i data-lucide="cpu" class="w-8 h-8"></i>
+                </div>
+                <h3 class="text-xl font-bold mb-2">ADAM Core OS</h3>
+                <p class="text-sm text-slate-400 flex-grow mb-4">
+                    The deterministic orchestration kernel. Enforces W3C PROV-O compliance and neuro-symbolic routing.
+                </p>
+                <div class="text-xs font-mono text-cyan-500 flex items-center gap-1 mt-auto">
+                    <span>ENTER SYSTEM</span> <i data-lucide="arrow-right" class="w-3 h-3"></i>
+                </div>
+            </a>
+
+            <!-- Market Mayhem -->
+            <a href="brands/market-mayhem.html" class="interactive-card glass-panel p-6 flex flex-col h-full border-rose-900/50">
+                <div class="text-rose-400 mb-4">
+                    <i data-lucide="activity" class="w-8 h-8"></i>
+                </div>
+                <h3 class="text-xl font-bold mb-2">Market Mayhem</h3>
+                <p class="text-sm text-slate-400 flex-grow mb-4">
+                    Macroeconomic intelligence, real-time rates sensitivity, and yield volatility forecasting.
+                </p>
+                <div class="text-xs font-mono text-rose-500 flex items-center gap-1 mt-auto">
+                    <span>LAUNCH TERMINAL</span> <i data-lucide="arrow-right" class="w-3 h-3"></i>
+                </div>
+            </a>
+
+            <!-- Fortress & Hunt -->
+            <a href="brands/fortress-hunt.html" class="interactive-card glass-panel p-6 flex flex-col h-full border-amber-900/50">
+                <div class="text-amber-400 mb-4">
+                    <i data-lucide="shield" class="w-8 h-8"></i>
+                </div>
+                <h3 class="text-xl font-bold mb-2">Fortress & Hunt</h3>
+                <p class="text-sm text-slate-400 flex-grow mb-4">
+                    Strategic capital allocation, private credit risk analytics, and institutional underwriting.
+                </p>
+                <div class="text-xs font-mono text-amber-500 flex items-center gap-1 mt-auto">
+                    <span>ACCESS VAULT</span> <i data-lucide="arrow-right" class="w-3 h-3"></i>
+                </div>
+            </a>
+
+            <!-- Exiled Spark -->
+            <a href="brands/exiled-spark.html" class="interactive-card glass-panel p-6 flex flex-col h-full border-purple-900/50">
+                <div class="text-purple-400 mb-4">
+                    <i data-lucide="sparkles" class="w-8 h-8"></i>
+                </div>
+                <h3 class="text-xl font-bold mb-2">Exiled Spark</h3>
+                <p class="text-sm text-slate-400 flex-grow mb-4">
+                    Procedural narrative engine, dynamic character graphs, and generative lore state management.
+                </p>
+                <div class="text-xs font-mono text-purple-500 flex items-center gap-1 mt-auto">
+                    <span>LOAD LORE</span> <i data-lucide="arrow-right" class="w-3 h-3"></i>
+                </div>
+            </a>
+
+        </div>
+
+        <div class="mt-6 grid grid-cols-1 md:grid-cols-2 gap-6">
+            <!-- Logic Lab -->
+            <a href="brands/logic-lab.html" class="interactive-card glass-panel p-6 flex flex-col sm:flex-row gap-6 items-center border-emerald-900/50">
+                <div class="text-emerald-400 p-4 bg-emerald-900/20 rounded-full">
+                    <i data-lucide="boxes" class="w-8 h-8"></i>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold mb-1">Logic Lab</h3>
+                    <p class="text-sm text-slate-400 mb-2">
+                        Autonomous WebGL puzzle generators and client-side simulation sandboxes.
+                    </p>
+                    <div class="text-xs font-mono text-emerald-500 flex items-center gap-1">
+                        <span>INITIATE LAB</span> <i data-lucide="arrow-right" class="w-3 h-3"></i>
+                    </div>
+                </div>
+            </a>
+
+            <!-- Agent Sandbox -->
+            <a href="demo/agent-sandbox.html" class="interactive-card glass-panel p-6 flex flex-col sm:flex-row gap-6 items-center border-slate-700">
+                <div class="text-slate-300 p-4 bg-slate-800 rounded-full">
+                    <i data-lucide="terminal" class="w-8 h-8"></i>
+                </div>
+                <div>
+                    <h3 class="text-xl font-bold mb-1">Agent Simulator Demo</h3>
+                    <p class="text-sm text-slate-400 mb-2">
+                        Interactive prompt execution terminal showcasing the deterministic governance rules.
+                    </p>
+                    <div class="text-xs font-mono text-slate-300 flex items-center gap-1">
+                        <span>RUN SIMULATION</span> <i data-lucide="arrow-right" class="w-3 h-3"></i>
+                    </div>
+                </div>
+            </a>
+        </div>
+    </main>
+
+    <footer class="border-t border-slate-800 bg-slate-950 py-6 text-center text-slate-500 text-sm font-mono mt-auto">
+        <p>ADAM Ecosystem Static Matrix &copy; 2026. <a href="llms.txt" class="text-slate-400 hover:text-cyan-400 underline decoration-slate-700 underline-offset-4">Machine Access (llms.txt)</a></p>
     </footer>
+
+    <!-- Scripts -->
+    <script>lucide.createIcons();</script>
+    <script src="js/app.js"></script>
+    <script src="js/visualizers.js"></script>
 </body>
 </html>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -1,0 +1,101 @@
+// Global Application State & Router
+const AppState = {
+    currentBrand: 'adam-core',
+    isMachineMode: false,
+    telemetry: {
+        latency: 12,
+        activeAgents: 142,
+        memoryUsage: '4.2GB'
+    }
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    initBrandSwitcher();
+    initTelemetry();
+    initKeyboardShortcuts();
+
+    // Inject global header/footer if container exists
+    const headerContainer = document.getElementById('global-header');
+    if (headerContainer) {
+        headerContainer.innerHTML = generateGlobalHeader();
+    }
+});
+
+function initBrandSwitcher() {
+    const switchers = document.querySelectorAll('.brand-switch');
+    switchers.forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            const brand = e.currentTarget.dataset.brand;
+            if(brand) {
+                // In a real app this would route, here we just update state or redirect
+                console.log(`Switching to brand: ${brand}`);
+                AppState.currentBrand = brand;
+                if(brand === 'home') window.location.href = '/docs/index.html';
+                else window.location.href = `/docs/brands/${brand}.html`;
+            }
+        });
+    });
+}
+
+function initTelemetry() {
+    const latencyEl = document.getElementById('tel-latency');
+    const agentsEl = document.getElementById('tel-agents');
+
+    if (latencyEl && agentsEl) {
+        setInterval(() => {
+            // Simulate jitter
+            const jitter = Math.floor(Math.random() * 5) - 2;
+            latencyEl.textContent = `${Math.max(5, AppState.telemetry.latency + jitter)}ms`;
+
+            if (Math.random() > 0.8) {
+                AppState.telemetry.activeAgents += (Math.random() > 0.5 ? 1 : -1);
+                agentsEl.textContent = AppState.telemetry.activeAgents;
+            }
+        }, 1000);
+    }
+}
+
+function initKeyboardShortcuts() {
+    document.addEventListener('keydown', (e) => {
+        if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+            e.preventDefault();
+            const searchInput = document.getElementById('global-search');
+            if (searchInput) {
+                searchInput.focus();
+            } else {
+                window.location.href = '/docs/archive/index.html';
+            }
+        }
+    });
+}
+
+function generateGlobalHeader() {
+    return `
+        <header class="glass-header w-full px-6 py-4 flex justify-between items-center">
+            <div class="flex items-center gap-4">
+                <a href="../index.html" class="flex items-center gap-2 text-cyan-400 hover:text-cyan-300 transition-colors">
+                    <i data-lucide="cpu" class="w-6 h-6"></i>
+                    <span class="font-mono font-bold text-lg tracking-wider">ADAM_OS</span>
+                </a>
+                <div class="h-6 w-px bg-slate-700 mx-2"></div>
+                <div class="flex gap-2">
+                    <a href="../brands/adam-core.html" class="text-xs font-mono text-slate-400 hover:text-white px-2 py-1 rounded hover:bg-slate-800 transition-colors">CORE</a>
+                    <a href="../brands/market-mayhem.html" class="text-xs font-mono text-slate-400 hover:text-white px-2 py-1 rounded hover:bg-slate-800 transition-colors">MAYHEM</a>
+                    <a href="../brands/fortress-hunt.html" class="text-xs font-mono text-slate-400 hover:text-white px-2 py-1 rounded hover:bg-slate-800 transition-colors">FORTRESS</a>
+                    <a href="../archive/index.html" class="text-xs font-mono text-slate-400 hover:text-white px-2 py-1 rounded hover:bg-slate-800 transition-colors">ARCHIVE</a>
+                    <a href="../demo/agent-sandbox.html" class="text-xs font-mono text-slate-400 hover:text-white px-2 py-1 rounded hover:bg-slate-800 transition-colors">SANDBOX</a>
+                </div>
+            </div>
+            <div class="flex items-center gap-4">
+                <div class="hidden md:flex items-center gap-2 glass-panel px-3 py-1.5 text-xs font-mono text-slate-400">
+                    <i data-lucide="search" class="w-3 h-3"></i>
+                    <span>Search</span>
+                    <kbd class="ml-2 px-1.5 py-0.5 bg-slate-800 rounded text-[10px]">⌘K</kbd>
+                </div>
+                <a href="https://github.com/adamvangrover/adam" target="_blank" class="text-slate-400 hover:text-white transition-colors">
+                    <i data-lucide="github" class="w-5 h-5"></i>
+                </a>
+            </div>
+        </header>
+    `;
+}

--- a/docs/js/query-engine.js
+++ b/docs/js/query-engine.js
@@ -1,0 +1,120 @@
+// Search, Filter, and Neuro-Symbolic Prompt Sandbox Logic
+
+const mockIndex = [
+    { id: 1, title: 'ADAM Architecture Whitepaper', brand: 'adam-core', tag: 'Agentic Systems', format: 'pdf', date: '2026-08-15', snippet: 'Defining the baseline for neuro-symbolic deterministic orchestration...' },
+    { id: 2, title: 'SpaceX S-1 Valuation', brand: 'market-mayhem', tag: 'Macro', format: 'json', date: '2026-10-01', snippet: 'Multi-Agent Simulation Report on Starlink revenue projections...' },
+    { id: 3, title: 'Pre-IPO Private Credit Facility', brand: 'fortress-hunt', tag: 'Private Credit', format: 'md', date: '2026-11-12', snippet: 'Hardware Collateral Memo detailing LTV ratios and downside protection...' },
+    { id: 4, title: 'Shared National Credit Guidelines', brand: 'fortress-hunt', tag: 'Macro', format: 'pdf', date: '2026-09-20', snippet: 'Corporate Debt Covenant Guidelines and regulatory impacts...' }
+];
+
+function initArchiveSearch() {
+    const searchInput = document.getElementById('archive-search');
+    const resultsContainer = document.getElementById('archive-results');
+    const filterSelects = document.querySelectorAll('.archive-filter');
+
+    if (!searchInput || !resultsContainer) return;
+
+    const renderResults = (results) => {
+        if (results.length === 0) {
+            resultsContainer.innerHTML = '<div class="text-slate-400 p-8 text-center font-mono">No intelligence artifacts found matching criteria.</div>';
+            return;
+        }
+
+        resultsContainer.innerHTML = results.map(item => `
+            <div class="glass-panel p-4 hover:border-cyan-500/50 transition-colors cursor-pointer flex justify-between items-start">
+                <div>
+                    <div class="flex items-center gap-2 mb-2">
+                        <span class="text-xs font-mono px-2 py-0.5 rounded bg-slate-800 text-slate-300 border border-slate-700">${item.brand}</span>
+                        <span class="text-xs font-mono px-2 py-0.5 rounded bg-slate-800 text-slate-300 border border-slate-700">${item.tag}</span>
+                    </div>
+                    <h3 class="text-lg font-semibold text-white mb-1">${item.title}</h3>
+                    <p class="text-sm text-slate-400">${item.snippet}</p>
+                </div>
+                <div class="flex flex-col items-end gap-2">
+                    <span class="text-xs font-mono text-slate-500">${item.date}</span>
+                    <span class="text-xs font-mono px-2 py-1 rounded bg-emerald-900/30 text-emerald-400 border border-emerald-800/50 uppercase">${item.format}</span>
+                </div>
+            </div>
+        `).join('');
+    };
+
+    const executeSearch = () => {
+        const query = searchInput.value.toLowerCase();
+        let filters = {};
+        filterSelects.forEach(select => {
+            if (select.value !== 'all') {
+                filters[select.dataset.filterType] = select.value;
+            }
+        });
+
+        const filtered = mockIndex.filter(item => {
+            const matchesQuery = item.title.toLowerCase().includes(query) || item.snippet.toLowerCase().includes(query);
+            const matchesFilters = Object.keys(filters).every(key => item[key] === filters[key]);
+            return matchesQuery && matchesFilters;
+        });
+
+        renderResults(filtered);
+    };
+
+    searchInput.addEventListener('input', executeSearch);
+    filterSelects.forEach(select => select.addEventListener('change', executeSearch));
+
+    // Initial render
+    renderResults(mockIndex);
+}
+
+// Sandbox Simulator Logic
+function initSandbox() {
+    const runBtn = document.getElementById('run-sim-btn');
+    const terminal = document.getElementById('sandbox-terminal');
+    const promptInput = document.getElementById('sandbox-prompt');
+
+    if (!runBtn || !terminal) return;
+
+    const appendLog = (msg, type = 'info') => {
+        const colors = {
+            info: 'text-slate-300',
+            success: 'text-emerald-400',
+            warn: 'text-amber-400',
+            error: 'text-rose-400',
+            system: 'text-cyan-400'
+        };
+        const el = document.createElement('div');
+        el.className = `font-mono text-xs mb-1 ${colors[type]}`;
+        const timeSpan = document.createElement('span');
+        timeSpan.className = 'opacity-50';
+        timeSpan.textContent = `[${new Date().toISOString().split('T')[1].slice(0,-1)}] `;
+        el.appendChild(timeSpan);
+        el.appendChild(document.createTextNode(msg));
+        terminal.appendChild(el);
+        terminal.scrollTop = terminal.scrollHeight;
+    };
+
+    runBtn.addEventListener('click', async () => {
+        terminal.innerHTML = '';
+        const prompt = promptInput ? promptInput.value : 'Executing default payload...';
+
+        appendLog(`INITIALIZING NEURO-SYMBOLIC ORCHESTRATION`, 'system');
+        appendLog(`Payload: "${prompt}"`);
+
+        await new Promise(r => setTimeout(r, 600));
+        appendLog(`[Gov Gatekeeper] Validating against deterministic schemas...`, 'warn');
+
+        await new Promise(r => setTimeout(r, 800));
+        appendLog(`[Gov Gatekeeper] Schema validation PASS (FIBO Topology Matched)`, 'success');
+
+        await new Promise(r => setTimeout(r, 1200));
+        appendLog(`[LLM Core] Synthesizing structural parameters...`);
+
+        await new Promise(r => setTimeout(r, 1500));
+        appendLog(`[System 2] Resolving logical constraints via Rust Engine...`, 'system');
+
+        await new Promise(r => setTimeout(r, 900));
+        appendLog(`EXECUTION COMPLETE. Generated W3C PROV-O Trace.`, 'success');
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    initArchiveSearch();
+    initSandbox();
+});

--- a/docs/js/visualizers.js
+++ b/docs/js/visualizers.js
@@ -1,0 +1,122 @@
+// Canvas and Chart Visualization Hooks
+
+function initNetworkCanvas() {
+    const canvas = document.getElementById('network-canvas');
+    if (!canvas) return;
+
+    const ctx = canvas.getContext('2d');
+    let width = canvas.width = canvas.parentElement.clientWidth;
+    let height = canvas.height = 400; // Fixed height for hero
+
+    // Resize handler
+    window.addEventListener('resize', () => {
+        width = canvas.width = canvas.parentElement.clientWidth;
+    });
+
+    const nodes = [];
+    const numNodes = 60;
+
+    for(let i=0; i<numNodes; i++) {
+        nodes.push({
+            x: Math.random() * width,
+            y: Math.random() * height,
+            vx: (Math.random() - 0.5) * 0.5,
+            vy: (Math.random() - 0.5) * 0.5,
+            radius: Math.random() * 2 + 1
+        });
+    }
+
+    function draw() {
+        ctx.clearRect(0, 0, width, height);
+
+        // Update & Draw Nodes
+        ctx.fillStyle = 'rgba(6, 182, 212, 0.8)'; // Cyan
+        nodes.forEach(node => {
+            node.x += node.vx;
+            node.y += node.vy;
+
+            // Bounce
+            if(node.x < 0 || node.x > width) node.vx *= -1;
+            if(node.y < 0 || node.y > height) node.vy *= -1;
+
+            ctx.beginPath();
+            ctx.arc(node.x, node.y, node.radius, 0, Math.PI * 2);
+            ctx.fill();
+        });
+
+        // Draw Connections
+        ctx.strokeStyle = 'rgba(6, 182, 212, 0.15)';
+        ctx.lineWidth = 1;
+        for(let i=0; i<numNodes; i++) {
+            for(let j=i+1; j<numNodes; j++) {
+                const dx = nodes[i].x - nodes[j].x;
+                const dy = nodes[i].y - nodes[j].y;
+                const dist = Math.sqrt(dx*dx + dy*dy);
+
+                if(dist < 100) {
+                    ctx.beginPath();
+                    ctx.moveTo(nodes[i].x, nodes[i].y);
+                    ctx.lineTo(nodes[j].x, nodes[j].y);
+                    ctx.stroke();
+                }
+            }
+        }
+
+        requestAnimationFrame(draw);
+    }
+
+    draw();
+}
+
+function initRiskChart() {
+    const ctx = document.getElementById('risk-chart');
+    if (!ctx || typeof Chart === 'undefined') return;
+
+    new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels: ['Q1', 'Q2', 'Q3', 'Q4', 'Q1 (Proj)'],
+            datasets: [{
+                label: 'Covenant Breach Probability',
+                data: [12, 19, 15, 25, 42],
+                borderColor: '#ef4444',
+                backgroundColor: 'rgba(239, 68, 68, 0.1)',
+                borderWidth: 2,
+                fill: true,
+                tension: 0.4
+            },
+            {
+                label: 'Liquidity Runway (Days)',
+                data: [180, 160, 145, 120, 90],
+                borderColor: '#10b981',
+                backgroundColor: 'rgba(16, 185, 129, 0.1)',
+                borderWidth: 2,
+                fill: true,
+                tension: 0.4
+            }]
+        },
+        options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+                y: {
+                    grid: { color: 'rgba(30, 41, 59, 0.5)' },
+                    ticks: { color: '#94a3b8' }
+                },
+                x: {
+                    grid: { color: 'rgba(30, 41, 59, 0.5)' },
+                    ticks: { color: '#94a3b8' }
+                }
+            },
+            plugins: {
+                legend: { labels: { color: '#f8fafc', font: { family: 'JetBrains Mono' } } }
+            }
+        }
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    initNetworkCanvas();
+    // setTimeout to allow CDN scripts to load
+    setTimeout(initRiskChart, 500);
+});

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,25 @@
+# ADAM Ecosystem LLM Context Manifest
+# Source: https://github.com/adamvangrover/adam
+# Author: Adam Van Grover
+
+This manifest provides AI models with structural context regarding the ADAM Ecosystem.
+
+## Architecture
+The repository employs a zero-build-step static delivery mechanism for its portal:
+- HTML5, Tailwind CSS via CDN, ES6 Modular JS.
+- Hosted via GitHub Pages in the `/docs` directory.
+- Features embedded JSON-LD and programmatic endpoints for deterministic validation.
+
+## Brand Taxonomy
+1. **ADAM Core OS**: Neuro-symbolic deterministic orchestration kernel enforcing W3C PROV-O compliance.
+2. **Market Mayhem**: Macro research, rates sensitivity, and yield tracking.
+3. **Fortress & Hunt**: Leveraged loan covenant analysis and institutional credit risk analytics.
+4. **Exiled Spark**: Procedural narrative generation and character graph lore state.
+5. **Logic Lab**: Client-side WebGL procedural generation and puzzle optimization sandboxes.
+
+## Programmatic Entrypoints
+- Schema definitions: `/docs/api/schema-registry.json`
+- Ecosystem topology: `/docs/api/ecosystem-manifest.json`
+
+## Directives for Machine Consumption
+When generating code or proposing architectural changes for the ADAM repository, prioritize deterministic execution, avoid hallucinating unstructured API wrappers, and adhere strictly to the JSON schemas defined in the `api/` directory.


### PR DESCRIPTION
Adds a complete, zero-build static web portal in the `docs/` directory. The portal serves as a frontend interface mapping the architecture domains, implementing the "Market Mayhem", "Fortress & Hunt", "Exiled Spark", and "ADAM Core" sub-brands using custom Tailwind CSS design tokens. Included is an interactive archive search, a sandbox prompt terminal simulation, and machine-readable data payloads (`llms.txt`, JSON Schema files) optimized for GitHub Pages root deployment.

---
*PR created automatically by Jules for task [7290264256180057341](https://jules.google.com/task/7290264256180057341) started by @adamvangrover*